### PR TITLE
network

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,12 @@
     "idb-plus-blob-store": "^1.1.2",
     "ipfs-repo": "^0.7.5",
     "lodash": "^4.11.2",
+    "libp2p-ipfs": "^0.3.5",
+    "multiaddr": "^1.4.1",
     "ncp": "^2.0.0",
+    "peer-book": "^0.1.0",
     "peer-id": "^0.6.6",
+    "peer-info": "^0.6.2",
     "rimraf": "^2.5.2"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,12 @@ const Network = require('./network')
 const decision = require('./decision')
 
 module.exports = class Bitwap {
-  constructor (p, libp2p, datastore) {
+  constructor (p, libp2p, datastore, peerBook) {
     // the ID of the peer to act on behalf of
     this.self = p
 
     // the network delivers messages
-    this.network = new Network(libp2p)
+    this.network = new Network(libp2p, peerBook, this)
 
     // local database
     this.datastore = datastore

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -1,18 +1,68 @@
 'use strict'
 
+const bl = require('bl')
+const fs = require('fs')
+const path = require('path')
+const protobuf = require('protocol-buffers')
+const pbm = protobuf(fs.readFileSync(path.join(__dirname, '../message/message.proto')))
+
 module.exports = class Network {
-  constructor (libp2p) {
-    // TODO: Implement me
+  constructor (libp2p, peerBook, bitswap) {
     this.libp2p = libp2p
+    this.peerBook = peerBook
+
+    this.libp2p.swarm.handle('/ipfs/bitswap/1.0.0', (conn) => {
+      conn.pipe(bl((err, data) => {
+        conn.end()
+        if (err) {
+          return bitswap._receiveError(err)
+        }
+        let msg
+        try {
+          msg = pbm.Message.decode(data)
+        } catch (err) {
+          return bitswap._receiveError(err)
+        }
+        bitswap._receiveMessage(conn.peerId, msg)
+      }))
+    })
+
+    this.libp2p.swarm.on('peer-mux-established', (peerInfo) => {
+      bitswap._onPeerConnected(peerInfo.id)
+    })
+
+    this.libp2p.swarm.on('peer-mux-closed', (peerInfo) => {
+      bitswap._onPeerDisconnected(peerInfo.id)
+    })
   }
 
   // Connect to the given peer
   connectTo (peerId, cb) {
-    // TODO: Implement me
+    // NOTE: For now, all this does is ensure that we are
+    // connected. Once we have Peer Routing, we will be able
+    // to find the Peer
+    if (this.libp2p.swarm.muxedConns[peerId.toB58String()]) {
+      cb()
+    } else {
+      cb(new Error('Could not connect to peer with peerId:', peerId.toB58String()))
+    }
   }
 
   // Send the given msg (instance of Message) to the given peer
   sendMessage (peerId, msg, cb) {
-    // TODO: Implement me
+    try {
+      const peerInfo = this.peerBook.getByMultihash(peerId.toBytes())
+      const conn = this.libp2p.swarm.dial(peerInfo, '/ipfs/bitswap/1.0.0', (err) => {
+        if (err) {
+          return cb(err)
+        }
+        const msgEncoded = pbm.Message.encode(msg)
+        conn.write(msgEncoded)
+        conn.end()
+        cb()
+      })
+    } catch (err) {
+      cb(err)
+    }
   }
 }

--- a/test/network/network.node.js
+++ b/test/network/network.node.js
@@ -1,0 +1,184 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const Network = require('./../../src/network')
+const libp2p = require('libp2p-ipfs')
+const PeerInfo = require('peer-info')
+const multiaddr = require('multiaddr')
+const expect = require('chai').expect
+const fs = require('fs')
+const path = require('path')
+const protobuf = require('protocol-buffers')
+const pbm = protobuf(fs.readFileSync(path.join(__dirname, '../../src/message/message.proto')))
+const PeerBook = require('peer-book')
+
+describe('network', () => {
+  let libp2pNodeA
+  let libp2pNodeB
+  let peerInfoA
+  let peerInfoB
+  let peerBookA
+  let peerBookB
+  let networkA
+  let networkB
+
+  before((done) => {
+    let counter = 0
+    peerInfoA = new PeerInfo()
+    peerInfoB = new PeerInfo()
+
+    peerInfoA.multiaddr.add(multiaddr('/ip4/127.0.0.1/tcp/10100'))
+    peerInfoB.multiaddr.add(multiaddr('/ip4/127.0.0.1/tcp/10500'))
+
+    peerBookA = new PeerBook()
+    peerBookB = new PeerBook()
+
+    peerBookA.put(peerInfoB)
+    peerBookB.put(peerInfoA)
+
+    libp2pNodeA = new libp2p.Node(peerInfoA)
+    libp2pNodeA.start(started)
+    libp2pNodeB = new libp2p.Node(peerInfoB)
+    libp2pNodeB.start(started)
+
+    function started () {
+      if (++counter === 2) {
+        done()
+      }
+    }
+  })
+
+  after((done) => {
+    let counter = 0
+    libp2pNodeA.swarm.close(stopped)
+    libp2pNodeB.swarm.close(stopped)
+
+    function stopped () {
+      if (++counter === 2) {
+        done()
+      }
+    }
+  })
+
+  var bitswapMockA = {
+    _receiveMessage: () => {},
+    _receiveError: () => {},
+    _onPeerConnected: () => {},
+    _onPeerDisconnected: () => {}
+  }
+
+  var bitswapMockB = {
+    _receiveMessage: () => {},
+    _receiveError: () => {},
+    _onPeerConnected: () => {},
+    _onPeerDisconnected: () => {}
+  }
+
+  it('instantiate the network obj', (done) => {
+    networkA = new Network(libp2pNodeA, peerBookA, bitswapMockA)
+    networkB = new Network(libp2pNodeB, peerBookB, bitswapMockB)
+    expect(networkA).to.exist
+    expect(networkB).to.exist
+    done()
+  })
+
+  it('connectTo fail', (done) => {
+    networkA.connectTo(peerInfoB.id, (err) => {
+      expect(err).to.exist
+      done()
+    })
+  })
+
+  it('onPeerConnected success', (done) => {
+    var counter = 0
+
+    bitswapMockA._onPeerConnected = (peerId) => {
+      expect(peerId.toB58String()).to.equal(peerInfoB.id.toB58String())
+      if (++counter === 2) {
+        finish()
+      }
+    }
+
+    bitswapMockB._onPeerConnected = (peerId) => {
+      expect(peerId.toB58String()).to.equal(peerInfoA.id.toB58String())
+      if (++counter === 2) {
+        finish()
+      }
+    }
+
+    libp2pNodeA.swarm.dial(peerInfoB, (err) => {
+      expect(err).to.not.exist
+    })
+
+    function finish () {
+      bitswapMockA._onPeerConnected = () => {}
+      bitswapMockB._onPeerConnected = () => {}
+      done()
+    }
+  })
+
+  it('connectTo success', (done) => {
+    networkA.connectTo(peerInfoB.id, (err) => {
+      expect(err).to.not.exist
+      done()
+    })
+  })
+
+  it('_receiveMessage success', (done) => {
+    const msg = {
+      wantlist: {
+        entries: [{
+          block: 'hello',
+          cancel: false,
+          priority: 0
+        }],
+        full: true
+      },
+      blocks: [new Buffer('hello'), new Buffer('world')]
+    }
+
+    bitswapMockB._receiveMessage = (peerId, msgReceived) => {
+      expect(msg).to.deep.equal(msgReceived)
+      bitswapMockB._receiveMessage = () => {}
+      bitswapMockB._receiveError = () => {}
+      done()
+    }
+
+    bitswapMockB._receiveError = (err) => {
+      expect(err).to.not.exist
+    }
+
+    const conn = libp2pNodeA.swarm.dial(peerInfoB, '/ipfs/bitswap/1.0.0', (err) => {
+      expect(err).to.not.exist
+    })
+
+    const msgEncoded = pbm.Message.encode(msg)
+    conn.write(msgEncoded)
+    conn.end()
+  })
+
+  it('sendMessage', (done) => {
+    const msg = {
+      wantlist: {
+        entries: [{
+          block: 'hello',
+          cancel: false,
+          priority: 0
+        }],
+        full: true
+      },
+      blocks: [new Buffer('hello'), new Buffer('world')]
+    }
+
+    bitswapMockB._receiveMessage = (peerId, msgReceived) => {
+      expect(msg).to.deep.equal(msgReceived)
+      bitswapMockB._receiveMessage = () => {}
+      done()
+    }
+
+    networkA.sendMessage(peerInfoB.id, msg, (err) => {
+      expect(err).to.not.exist
+    })
+  })
+})

--- a/test/node.js
+++ b/test/node.js
@@ -36,3 +36,4 @@ const repo = {
 
 require('./index-test')(repo)
 require('./decision/engine-test')(repo)
+require('./network/network.node.js')


### PR DESCRIPTION
This is a **WIP**, missing: 

- [x] Update Swarm with `peer-mux-*` events
- [x] Update peerBook on js-ipfs to make it smarter when it comes to updating the info about a peer (with the option to flush it to disk) and indexing. So that I can fetch the peerInfo for `sendMessage` call
- [x] Update Swarm to patch the peerId to the conn (and the streams that are multiplexed on the conn), so that we can do the `_receiveMessage`