### PR TITLE
Prevent double callback in getBlocks.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,7 @@ module.exports = class Bitwap {
       })
     }
 
+    let finished = false
     const finish = (key, err, block) => {
       results[key] = {
         error: err,
@@ -198,7 +199,11 @@ module.exports = class Bitwap {
 
       if (Object.keys(results).length === keys.length) {
         cleanupListeners()
-        cb(results)
+
+        if (!finished) {
+          cb(results)
+        }
+        finished = true
       }
     }
 


### PR DESCRIPTION
I found this after doing some digging in https://github.com/ipfs/js-ipfs/issues/318.

It looks like we can call `finish` both [here](https://github.com/ipfs/js-ipfs-bitswap/blob/master/src/index.js#L185) *and* [here](https://github.com/ipfs/js-ipfs-bitswap/blob/master/src/index.js#L227).

As far as I've been able to tell, a getBlock request will reach [datastore.get](https://github.com/ipfs/js-ipfs-bitswap/blob/master/src/index.js#L221)  and block there because the `put` is still in progress. At this point the notification handler [here](https://github.com/ipfs/js-ipfs-bitswap/blob/master/src/index.js#L189) will be set up. Once the block finishes being `put`, it both a) fires the notification, and also b) makes that earlier `datastore.get` return successfully, making `finish` get called twice.

I'm not very familiar with this module, so let me know if there's a more complete fix here than simply preventing the cb from running twice! :heart: