### PR TITLE
Tell browserify to fix up fs.readFileSync calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "url": "https://github.com/ipfs/js-ipfs-bitswap/issues"
   },
   "homepage": "https://github.com/ipfs/js-ipfs-bitswap#readme",
+  "browserify": {
+      "transform": [ "brfs" ]
+  },
   "devDependencies": {
     "aegir": "^8.0.1",
     "buffer-loader": "0.0.1",


### PR DESCRIPTION
@substack suggested that this would make browserify able to actually package this module. Without running through brfs, it packages up just fine, but browserify provides an empty `fs` implementation, so when this module goes to load the .proto files on startup it fails.
