### PR TITLE
stats improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "lodash.sortby": "^4.7.0",
     "lodash.uniqwith": "^4.5.0",
     "lodash.values": "^4.3.0",
+    "moving-average": "^1.0.0",
     "multicodec": "~0.2.5",
     "multihashing-async": "~0.4.7",
     "protons": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "async": "^2.6.0",
+    "big.js": "^5.0.3",
     "cids": "~0.5.2",
     "debug": "^3.1.0",
     "ipfs-block": "~0.6.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "peer-book": "~0.5.1",
     "peer-id": "~0.10.2",
     "peer-info": "~0.11.1",
+    "pre-commit": "^1.2.2",
     "rimraf": "^2.6.2",
     "safe-buffer": "^5.1.1"
   },
@@ -80,6 +81,10 @@
     "safe-buffer": "^5.1.1",
     "varint-decoder": "^0.1.1"
   },
+  "pre-commit": [
+    "lint",
+    "test"
+  ],
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",
     "Dmitriy Ryajov <dryajov@gmail.com>",

--- a/src/decision-engine/index.js
+++ b/src/decision-engine/index.js
@@ -21,10 +21,11 @@ const logger = require('../utils').logger
 const MAX_MESSAGE_SIZE = 512 * 1024
 
 class DecisionEngine {
-  constructor (peerId, blockstore, network) {
+  constructor (peerId, blockstore, network, stats) {
     this._log = logger(peerId, 'engine')
     this.blockstore = blockstore
     this.network = network
+    this._stats = stats
 
     // A list of of ledgers by their partner id
     this.ledgerMap = new Map()
@@ -267,6 +268,9 @@ class DecisionEngine {
     const l = new Ledger(peerId)
 
     this.ledgerMap.set(peerIdStr, l)
+    if (this._stats) {
+      this._stats.push('peerCount', 1)
+    }
 
     return l
   }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,8 @@ const statsKeys = [
   'blocksReceived',
   'dataReceived',
   'dupBlksReceived',
-  'dupDataReceived'
+  'dupDataReceived',
+  'dataSent'
 ]
 
 /**
@@ -36,13 +37,16 @@ class Bitswap {
     this._libp2p = libp2p
     this._log = logger(this.peerInfo.id)
 
+    this._options = Object.assign({}, defaultOptions, options)
+
+    // stats
+    this._stats = new Stats(statsKeys, this._options.statsUpdateInterval)
+
     // the network delivers messages
-    this.network = new Network(libp2p, this)
+    this.network = new Network(libp2p, this, {}, this._stats)
 
     // local database
     this.blockstore = blockstore
-
-    this._options = Object.assign({}, defaultOptions, options)
 
     this.engine = new DecisionEngine(this.peerInfo.id, blockstore, this.network)
 
@@ -50,7 +54,6 @@ class Bitswap {
     this.wm = new WantManager(this.peerInfo.id, this.network)
 
     this.notifications = new Notifications(this.peerInfo.id)
-    this._stats = new Stats(statsKeys, this._options.statsUpdateInterval)
   }
 
   get peerInfo () {

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const defaultOptions = {
 }
 const statsKeys = [
   'blocksReceived',
+  'dataReceived',
   'dupBlksReceived',
   'dupDataReceived'
 ]
@@ -105,6 +106,7 @@ class Bitswap {
 
   _updateReceiveCounters (block, exists) {
     this._stats.push('blocksReceived', 1)
+    this._stats.push('dataReceived', block.data.length)
 
     if (exists) {
       this._stats.push('dupBlksReceived', 1)

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,8 @@ const statsKeys = [
   'dupDataReceived',
   'blocksSent',
   'dataSent',
-  'providesBufferLength'
+  'providesBufferLength',
+  'wantListLength'
 ]
 
 /**
@@ -57,7 +58,7 @@ class Bitswap {
     this.engine = new DecisionEngine(this.peerInfo.id, blockstore, this.network)
 
     // handle message sending
-    this.wm = new WantManager(this.peerInfo.id, this.network)
+    this.wm = new WantManager(this.peerInfo.id, this.network, this._stats)
 
     this.notifications = new Notifications(this.peerInfo.id)
   }
@@ -349,10 +350,19 @@ class Bitswap {
   /**
    * Get the current list of wants.
    *
-   * @returns {Array<WantlistEntry>}
+   * @returns {Iterator<WantlistEntry>}
    */
   getWantlist () {
     return this.wm.wantlist.entries()
+  }
+
+  /**
+   * Get the current list of partners.
+   *
+   * @returns {Array<PeerId>}
+   */
+  peers () {
+    return this.engine.peers()
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ const logger = require('./utils').logger
 const Stats = require('./stats')
 
 const defaultOptions = {
-  statsUpdateInterval: 5000
+  statsComputeThrottleTimeout: 1000,
+  statsComputeThrottleMaxQueueSize: 1000
 }
 const statsKeys = [
   'blocksReceived',
@@ -41,7 +42,10 @@ class Bitswap {
     this._options = Object.assign({}, defaultOptions, options)
 
     // stats
-    this._stats = new Stats(statsKeys, this._options.statsUpdateInterval)
+    this._stats = new Stats(statsKeys, {
+      computeThrottleTimeout: this._options.statsComputeThrottleTimeout,
+      computeThrottleMaxQueueSize: this._options.statsComputeThrottleMaxQueueSize
+    })
 
     // the network delivers messages
     this.network = new Network(libp2p, this, {}, this._stats)
@@ -367,7 +371,6 @@ class Bitswap {
    * @returns {void}
    */
   start (callback) {
-    this._stats.start()
     series([
       (cb) => this.wm.start(cb),
       (cb) => this.network.start(cb),
@@ -383,7 +386,6 @@ class Bitswap {
    * @returns {void}
    */
   stop (callback) {
-    this._stats.stop()
     series([
       (cb) => this.wm.stop(cb),
       (cb) => this.network.stop(cb),

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,8 @@ const statsKeys = [
   'dupBlksReceived',
   'dupDataReceived',
   'blocksSent',
-  'dataSent'
+  'dataSent',
+  'providesBufferLength'
 ]
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ const logger = require('./utils').logger
 const Stats = require('./stats')
 
 const defaultOptions = {
+  statsEnabled: false,
   statsComputeThrottleTimeout: 1000,
   statsComputeThrottleMaxQueueSize: 1000
 }
@@ -46,6 +47,7 @@ class Bitswap {
 
     // stats
     this._stats = new Stats(statsKeys, {
+      enabled: this._options.statsEnabled,
       computeThrottleTimeout: this._options.statsComputeThrottleTimeout,
       computeThrottleMaxQueueSize: this._options.statsComputeThrottleMaxQueueSize
     })
@@ -157,6 +159,14 @@ class Bitswap {
       this.engine.receivedBlocks([block.cid])
       callback()
     })
+  }
+
+  enableStats () {
+    this._stats.enable()
+  }
+
+  disableStats () {
+    this._stats.disable()
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,8 @@ const statsKeys = [
   'blocksSent',
   'dataSent',
   'providesBufferLength',
-  'wantListLength'
+  'wantListLength',
+  'peerCount'
 ]
 
 /**
@@ -55,7 +56,7 @@ class Bitswap {
     // local database
     this.blockstore = blockstore
 
-    this.engine = new DecisionEngine(this.peerInfo.id, blockstore, this.network)
+    this.engine = new DecisionEngine(this.peerInfo.id, blockstore, this.network, this._stats)
 
     // handle message sending
     this.wm = new WantManager(this.peerInfo.id, this.network, this._stats)

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ const statsKeys = [
   'dataReceived',
   'dupBlksReceived',
   'dupDataReceived',
+  'blocksSent',
   'dataSent'
 ]
 

--- a/src/network.js
+++ b/src/network.js
@@ -150,7 +150,7 @@ class Network {
         }
       })
       callback()
-      this._updateSentStats(serialized.length)
+      this._updateSentStats(msg.blocks)
     })
   }
 
@@ -179,9 +179,10 @@ class Network {
     })
   }
 
-  _updateSentStats (sentSize) {
+  _updateSentStats (blocks) {
     if (this._stats) {
-      this._stats.push('dataSent', sentSize)
+      blocks.forEach((block) => this._stats.push('dataSent', block.data.length))
+      this._stats.push('blocksSent', blocks.size)
     }
   }
 }

--- a/src/network.js
+++ b/src/network.js
@@ -14,13 +14,14 @@ const BITSWAP100 = '/ipfs/bitswap/1.0.0'
 const BITSWAP110 = '/ipfs/bitswap/1.1.0'
 
 class Network {
-  constructor (libp2p, bitswap, options) {
+  constructor (libp2p, bitswap, options, stats) {
     this._log = logger(libp2p.peerInfo.id, 'network')
     options = options || {}
     this.libp2p = libp2p
     this.bitswap = bitswap
     this.b100Only = options.b100Only || false
 
+    this._stats = stats
     this._running = false
   }
 
@@ -149,6 +150,7 @@ class Network {
         }
       })
       callback()
+      this._updateSentStats(serialized.length)
     })
   }
 
@@ -175,6 +177,12 @@ class Network {
 
       callback(null, conn, BITSWAP110)
     })
+  }
+
+  _updateSentStats (sentSize) {
+    if (this._stats) {
+      this._stats.push('dataSent', sentSize)
+    }
   }
 }
 

--- a/src/stats.js
+++ b/src/stats.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const EventEmitter = require('events')
+
+class Stats extends EventEmitter {
+  constructor (initialCounters, updateInterval) {
+    super()
+
+    if (typeof updateInterval !== 'number') {
+      throw new Error('need updateInterval')
+    }
+
+    this._updateInterval = updateInterval
+    this._queue = []
+    this._stats = {}
+
+    initialCounters.forEach((key) => this._stats[key] = 0)
+  }
+
+  start () {
+    this._startUpdater()
+  }
+
+  get snapshot () {
+    return this._stats
+  }
+
+  push (counter, inc) {
+    this._queue.push([counter, inc])
+  }
+
+  _startUpdater () {
+    if (!this._updater) {
+      this._updater = setInterval(this._update.bind(this), this._updateInterval)
+    }
+  }
+
+  _update () {
+    if (this._queue.length) {
+      while (this._queue.length) {
+        const op = this._queue.shift()
+        this._applyOp(op)
+      }
+      this.emit('update', this._stats)
+    }
+  }
+
+  _applyOp (op) {
+    const key = op[0]
+    const inc = op[1]
+
+    if (typeof inc !== 'number') {
+      throw new Error('invalid increment number:', inc)
+    }
+
+    if (!this._stats.hasOwnProperty(key)) {
+      this._stats[key] = 0
+    }
+    this._stats[key] += inc
+  }
+
+
+  stop () {
+    if (this._updater) {
+      clearInterval(this._updater)
+      this._updater = null
+    }
+  }
+}
+
+module.exports = Stats

--- a/src/stats.js
+++ b/src/stats.js
@@ -14,7 +14,7 @@ class Stats extends EventEmitter {
     this._queue = []
     this._stats = {}
 
-    initialCounters.forEach((key) => this._stats[key] = 0)
+    initialCounters.forEach((key) => { this._stats[key] = 0 })
   }
 
   start () {
@@ -58,7 +58,6 @@ class Stats extends EventEmitter {
     }
     this._stats[key] += inc
   }
-
 
   stop () {
     if (this._updater) {

--- a/src/stats.js
+++ b/src/stats.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const EventEmitter = require('events')
+const Big = require('big.js')
 
 class Stats extends EventEmitter {
   constructor (initialCounters, updateInterval) {
@@ -14,7 +15,7 @@ class Stats extends EventEmitter {
     this._queue = []
     this._stats = {}
 
-    initialCounters.forEach((key) => { this._stats[key] = 0 })
+    initialCounters.forEach((key) => { this._stats[key] = Big(0) })
   }
 
   start () {
@@ -53,10 +54,14 @@ class Stats extends EventEmitter {
       throw new Error('invalid increment number:', inc)
     }
 
+    let n
+
     if (!this._stats.hasOwnProperty(key)) {
-      this._stats[key] = 0
+      n = this._stats[key] = Big(0)
+    } else {
+      n = this._stats[key]
     }
-    this._stats[key] += inc
+    this._stats[key] = n.plus(inc)
   }
 
   stop () {

--- a/src/stats.js
+++ b/src/stats.js
@@ -22,7 +22,7 @@ class Stats extends EventEmitter {
   }
 
   get snapshot () {
-    return this._stats
+    return Object.assign({}, this._stats)
   }
 
   push (counter, inc) {
@@ -60,10 +60,8 @@ class Stats extends EventEmitter {
   }
 
   stop () {
-    if (this._updater) {
-      clearInterval(this._updater)
-      this._updater = null
-    }
+    clearInterval(this._updater)
+    this._updater = null
   }
 }
 

--- a/src/stats.js
+++ b/src/stats.js
@@ -30,21 +30,20 @@ class Stats extends EventEmitter {
 
   push (counter, inc) {
     this._queue.push([counter, inc])
-    if (this._queue.length <= this._options.computeThrottleMaxQueueSize) {
-      this._resetComputeTimeout()
-    } else {
-      if (this._timeout) {
-        clearTimeout(this._timeout)
-      }
-      this._update()
-    }
+    this._resetComputeTimeout()
   }
 
   _resetComputeTimeout () {
     if (this._timeout) {
       clearTimeout(this._timeout)
     }
-    this._timeout = setTimeout(this._update, this._options.computeThrottleTimeout)
+    this._timeout = setTimeout(this._update, this._nextTimeout())
+  }
+
+  _nextTimeout () {
+    // calculate the need for an update, depending on the queue length
+    const urgency = this._queue.length / this._options.computeThrottleMaxQueueSize
+    return Math.max(this._options.computeThrottleTimeout * (1 - urgency), 0)
   }
 
   _update () {

--- a/src/stats.js
+++ b/src/stats.js
@@ -35,7 +35,6 @@ class Stats extends EventEmitter {
     this._movingAverages = {}
 
     this._update = this._update.bind(this)
-    this._updateFrequency = this._updateFrequency.bind(this)
 
     initialCounters.forEach((key) => {
       this._stats[key] = Big(0)
@@ -45,6 +44,16 @@ class Stats extends EventEmitter {
         ma.push(this._frequencyLastTime, 0)
       })
     })
+
+    this._enabled = this._options.enabled
+  }
+
+  enable () {
+    this._enabled = true
+  }
+
+  disable () {
+    this._disabled = true
   }
 
   get snapshot () {
@@ -56,8 +65,10 @@ class Stats extends EventEmitter {
   }
 
   push (counter, inc) {
-    this._queue.push([counter, inc, Date.now()])
-    this._resetComputeTimeout()
+    if (this._enabled) {
+      this._queue.push([counter, inc, Date.now()])
+      this._resetComputeTimeout()
+    }
   }
 
   _resetComputeTimeout () {

--- a/src/types/wantlist/index.js
+++ b/src/types/wantlist/index.js
@@ -4,8 +4,9 @@ const sort = require('lodash.sortby')
 const Entry = require('./entry')
 
 class Wantlist {
-  constructor () {
+  constructor (stats) {
     this.set = new Map()
+    this._stats = stats
   }
 
   get length () {
@@ -21,6 +22,9 @@ class Wantlist {
       entry.priority = priority
     } else {
       this.set.set(cidStr, new Entry(cid, priority))
+      if (this._stats) {
+        this._stats.push('wantListSize', 1)
+      }
     }
   }
 
@@ -40,6 +44,9 @@ class Wantlist {
     }
 
     this.set.delete(cidStr)
+    if (this._stats) {
+      this._stats.push('wantListSize', -1)
+    }
   }
 
   removeForce (cidStr) {

--- a/src/want-manager/index.js
+++ b/src/want-manager/index.js
@@ -9,11 +9,12 @@ const MsgQueue = require('./msg-queue')
 const logger = require('../utils').logger
 
 module.exports = class WantManager {
-  constructor (peerId, network) {
+  constructor (peerId, network, stats) {
     this.peers = new Map()
-    this.wantlist = new Wantlist()
+    this.wantlist = new Wantlist(stats)
 
     this.network = network
+    this._stats = stats
 
     this._peerId = peerId
     this._log = logger(peerId, 'want')

--- a/test/bitswap-mock-internals.js
+++ b/test/bitswap-mock-internals.js
@@ -24,7 +24,9 @@ const storeHasBlocks = require('./utils/store-has-blocks')
 const makeBlock = require('./utils/make-block')
 const orderedFinish = require('./utils/helpers').orderedFinish
 
-describe('bitswap with mocks', () => {
+describe('bitswap with mocks', function () {
+  this.timeout(10 * 1000)
+
   let repo
   let blocks
   let ids

--- a/test/bitswap-mock-internals.js
+++ b/test/bitswap-mock-internals.js
@@ -66,8 +66,6 @@ describe('bitswap with mocks', () => {
 
         bs._receiveMessage(other, msg, (err) => {
           expect(err).to.not.exist()
-          expect(bs.blocksRecvd).to.equal(2)
-          expect(bs.dupBlocksRecvd).to.equal(0)
 
           map([b1.cid, b2.cid], (cid, cb) => repo.blocks.get(cid, cb), (err, blocks) => {
             expect(err).to.not.exist()
@@ -95,9 +93,6 @@ describe('bitswap with mocks', () => {
 
         bs._receiveMessage(other, msg, (err) => {
           expect(err).to.not.exist()
-
-          expect(bs.blocksRecvd).to.be.eql(0)
-          expect(bs.dupBlocksRecvd).to.be.eql(0)
 
           const wl = bs.wantlistForPeer(other)
 
@@ -325,19 +320,6 @@ describe('bitswap with mocks', () => {
           }
         ], done)
       })
-    })
-  })
-
-  describe('stat', () => {
-    it('has initial stats', () => {
-      const bs = new Bitswap(mockLibp2pNode(), {})
-
-      const stats = bs.stat()
-      expect(stats).to.have.property('wantlist')
-      expect(stats).to.have.property('blocksReceived', 0)
-      expect(stats).to.have.property('dupBlksReceived', 0)
-      expect(stats).to.have.property('dupDataReceived', 0)
-      expect(stats).to.have.property('peers')
     })
   })
 

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -86,7 +86,7 @@ describe('bitswap stats', () => {
 
   before(() => {
     bitswaps = nodes.map((node, i) => new Bitswap(libp2pNodes[i], repos[i].blocks, {
-      statsComputeThrottleTimeout: 100 // fast update interval for so tests run fast
+      statsComputeThrottleTimeout: 500 // fast update interval for so tests run fast
     }))
     bs = bitswaps[0]
   })
@@ -130,6 +130,8 @@ describe('bitswap stats', () => {
       expect(stats.blocksSent.eq(0)).to.be.true()
       expect(stats.dataSent.eq(0)).to.be.true()
       expect(stats.providesBufferLength.eq(0)).to.be.true()
+      expect(stats.wantListLength.eq(0)).to.be.true()
+      expect(stats.peerCount.eq(1)).to.be.true()
 
       // test moving averages
       const movingAverages = bs.stat().movingAverages
@@ -219,7 +221,6 @@ describe('bitswap stats', () => {
     it('updates stats on transfer', (done) => {
       const finish = orderedFinish(2, done)
       bs.stat().once('update', (stats) => {
-        console.log(stats.blocksReceived.toJSON())
         expect(stats.blocksReceived.eq(4)).to.be.true()
         expect(stats.dataReceived.eq(192)).to.be.true()
         expect(stats.dupBlksReceived.eq(2)).to.be.true()
@@ -228,6 +229,7 @@ describe('bitswap stats', () => {
         expect(stats.dataSent.eq(48)).to.be.true()
         expect(stats.providesBufferLength.eq(0)).to.be.true()
         expect(stats.wantListLength.eq(0)).to.be.true()
+        expect(stats.peerCount.eq(2)).to.be.true()
         finish(2)
       })
 

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -1,12 +1,8 @@
 /* eslint-env mocha */
-/* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
-const eachSeries = require('async/eachSeries')
-const waterfall = require('async/waterfall')
 const map = require('async/map')
 const parallel = require('async/parallel')
-const setImmediate = require('async/setImmediate')
 const _ = require('lodash')
 const chai = require('chai')
 chai.use(require('dirty-chai'))
@@ -17,12 +13,8 @@ const Message = require('../src/types/message')
 const Bitswap = require('../src')
 
 const createTempRepo = require('./utils/create-temp-repo-nodejs')
-const mockNetwork = require('./utils/mocks').mockNetwork
-const applyNetwork = require('./utils/mocks').applyNetwork
 const mockLibp2pNode = require('./utils/mocks').mockLibp2pNode
-const storeHasBlocks = require('./utils/store-has-blocks')
 const makeBlock = require('./utils/make-block')
-const orderedFinish = require('./utils/helpers').orderedFinish
 
 describe.only('bitswap stats', () => {
   let repo

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -88,6 +88,7 @@ describe('bitswap stats', () => {
     expect(stats).to.have.property('dataReceived', 0)
     expect(stats).to.have.property('dupBlksReceived', 0)
     expect(stats).to.have.property('dupDataReceived', 0)
+    expect(stats).to.have.property('blocksSent', 0)
     expect(stats).to.have.property('dataSent', 0)
   })
 
@@ -98,6 +99,7 @@ describe('bitswap stats', () => {
       expect(stats).to.have.property('dataReceived', 96)
       expect(stats).to.have.property('dupBlksReceived', 0)
       expect(stats).to.have.property('dupDataReceived', 0)
+      expect(stats).to.have.property('blocksSent', 0)
       expect(stats).to.have.property('dataSent', 0)
       done()
     })
@@ -119,6 +121,7 @@ describe('bitswap stats', () => {
       expect(stats).to.have.property('dataReceived', 192)
       expect(stats).to.have.property('dupBlksReceived', 2)
       expect(stats).to.have.property('dupDataReceived', 96)
+      expect(stats).to.have.property('blocksSent', 0)
       expect(stats).to.have.property('dataSent', 0)
       done()
     })
@@ -177,7 +180,8 @@ describe('bitswap stats', () => {
         expect(stats).to.have.property('dataReceived', 192)
         expect(stats).to.have.property('dupBlksReceived', 2)
         expect(stats).to.have.property('dupDataReceived', 96)
-        expect(stats).to.have.property('dataSent', 60)
+        expect(stats).to.have.property('blocksSent', 1)
+        expect(stats).to.have.property('dataSent', 48)
         done()
       })
 

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -1,0 +1,114 @@
+/* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 8] */
+'use strict'
+
+const eachSeries = require('async/eachSeries')
+const waterfall = require('async/waterfall')
+const map = require('async/map')
+const parallel = require('async/parallel')
+const setImmediate = require('async/setImmediate')
+const _ = require('lodash')
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+const PeerId = require('peer-id')
+
+const Message = require('../src/types/message')
+const Bitswap = require('../src')
+
+const createTempRepo = require('./utils/create-temp-repo-nodejs')
+const mockNetwork = require('./utils/mocks').mockNetwork
+const applyNetwork = require('./utils/mocks').applyNetwork
+const mockLibp2pNode = require('./utils/mocks').mockLibp2pNode
+const storeHasBlocks = require('./utils/store-has-blocks')
+const makeBlock = require('./utils/make-block')
+const orderedFinish = require('./utils/helpers').orderedFinish
+
+describe.only('bitswap stats', () => {
+  let repo
+  let blocks
+  let ids
+  let bs
+
+  before((done) => {
+    parallel(
+      {
+        repo: (cb) => createTempRepo(cb),
+        blocks: (cb) => map(_.range(15), (i, cb) => makeBlock(cb), cb),
+        ids: (cb) => map(_.range(2), (i, cb) => PeerId.create({bits: 1024}, cb), cb)
+      },
+      (err, results) => {
+        if (err) {
+          return done(err)
+        }
+
+        repo = results.repo
+        blocks = results.blocks
+        ids = results.ids
+
+        done()
+      }
+    )
+  })
+
+  before(() => {
+    bs = new Bitswap(mockLibp2pNode(), repo.blocks, {
+      statsUpdateInterval: 100 // fast update interval for so tests run fast
+    })
+  })
+
+  before((done) => bs.start(done))
+
+  after((done) => bs.stop(done))
+
+  after((done) => repo.teardown(done))
+
+  it('has initial stats', () => {
+    const stats = bs.stat().snapshot
+    expect(stats).to.have.property('blocksReceived', 0)
+    expect(stats).to.have.property('dupBlksReceived', 0)
+    expect(stats).to.have.property('dupDataReceived', 0)
+  })
+
+  it('updates blocks received', (done) => {
+    bs.start((err) => {
+      expect(err).to.not.exist()
+
+      const stats = bs.stat()
+      stats.once('update', (stats) => {
+        expect(stats).to.have.property('blocksReceived', 2)
+        expect(stats).to.have.property('dupBlksReceived', 0)
+        expect(stats).to.have.property('dupDataReceived', 0)
+        done()
+      })
+
+      const other = ids[1]
+
+      const msg = new Message(false)
+      blocks.slice(0, 2).forEach((block) => msg.addBlock(block))
+
+      bs._receiveMessage(other, msg, (err) => {
+        expect(err).to.not.exist()
+      })
+    })
+  })
+
+  it('updates duplicate blocks counters', (done) => {
+    const stats = bs.stat()
+    stats.once('update', (stats) => {
+      expect(stats).to.have.property('blocksReceived', 4)
+      expect(stats).to.have.property('dupBlksReceived', 2)
+      expect(stats).to.have.property('dupDataReceived', 96)
+      done()
+    })
+
+    const other = ids[1]
+
+    const msg = new Message(false)
+    blocks.slice(0, 2).forEach((block) => msg.addBlock(block))
+
+    bs._receiveMessage(other, msg, (err) => {
+      expect(err).to.not.exist()
+    })
+  })
+})

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -127,6 +127,7 @@ describe('bitswap stats', () => {
       expect(stats.dupDataReceived.eq(0)).to.be.true()
       expect(stats.blocksSent.eq(0)).to.be.true()
       expect(stats.dataSent.eq(0)).to.be.true()
+      expect(stats.providesBufferLength.eq(0)).to.be.true()
 
       // test moving averages
       const movingAverages = bs.stat().movingAverages
@@ -167,6 +168,7 @@ describe('bitswap stats', () => {
       expect(stats.dupDataReceived.eq(96)).to.be.true()
       expect(stats.blocksSent.eq(0)).to.be.true()
       expect(stats.dataSent.eq(0)).to.be.true()
+      expect(stats.providesBufferLength.eq(0)).to.be.true()
       done()
     })
 
@@ -222,6 +224,7 @@ describe('bitswap stats', () => {
         expect(stats.dupDataReceived.eq(96)).to.be.true()
         expect(stats.blocksSent.eq(1)).to.be.true()
         expect(stats.dataSent.eq(48)).to.be.true()
+        expect(stats.providesBufferLength.eq(0)).to.be.true()
         done()
       })
 

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -86,6 +86,7 @@ describe('bitswap stats', () => {
 
   before(() => {
     bitswaps = nodes.map((node, i) => new Bitswap(libp2pNodes[i], repos[i].blocks, {
+      statsEnabled: true,
       statsComputeThrottleTimeout: 500 // fast update interval for so tests run fast
     }))
     bs = bitswaps[0]

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -30,7 +30,7 @@ describe('bitswap stats', () => {
   before((done) => {
     parallel(
       {
-        blocks: (cb) => map(_.range(15), (i, cb) => makeBlock(cb), cb),
+        blocks: (cb) => map(_.range(2), (i, cb) => makeBlock(cb), cb),
         ids: (cb) => map(_.range(2), (i, cb) => PeerId.create({bits: 1024}, cb), cb)
       },
       (err, results) => {
@@ -84,30 +84,30 @@ describe('bitswap stats', () => {
 
   it('has initial stats', () => {
     const stats = bs.stat().snapshot
-    expect(stats).to.have.property('blocksReceived', 0)
-    expect(stats).to.have.property('dataReceived', 0)
-    expect(stats).to.have.property('dupBlksReceived', 0)
-    expect(stats).to.have.property('dupDataReceived', 0)
-    expect(stats).to.have.property('blocksSent', 0)
-    expect(stats).to.have.property('dataSent', 0)
+    expect(stats.blocksReceived.eq(0)).to.be.true()
+    expect(stats.dataReceived.eq(0)).to.be.true()
+    expect(stats.dupBlksReceived.eq(0)).to.be.true()
+    expect(stats.dupDataReceived.eq(0)).to.be.true()
+    expect(stats.blocksSent.eq(0)).to.be.true()
+    expect(stats.dataSent.eq(0)).to.be.true()
   })
 
   it('updates blocks received', (done) => {
     const stats = bs.stat()
     stats.once('update', (stats) => {
-      expect(stats).to.have.property('blocksReceived', 2)
-      expect(stats).to.have.property('dataReceived', 96)
-      expect(stats).to.have.property('dupBlksReceived', 0)
-      expect(stats).to.have.property('dupDataReceived', 0)
-      expect(stats).to.have.property('blocksSent', 0)
-      expect(stats).to.have.property('dataSent', 0)
+      expect(stats.blocksReceived.eq(2)).to.be.true()
+      expect(stats.dataReceived.eq(96)).to.be.true()
+      expect(stats.dupBlksReceived.eq(0)).to.be.true()
+      expect(stats.dupDataReceived.eq(0)).to.be.true()
+      expect(stats.blocksSent.eq(0)).to.be.true()
+      expect(stats.dataSent.eq(0)).to.be.true()
       done()
     })
 
     const other = ids[1]
 
     const msg = new Message(false)
-    blocks.slice(0, 2).forEach((block) => msg.addBlock(block))
+    blocks.forEach((block) => msg.addBlock(block))
 
     bs._receiveMessage(other, msg, (err) => {
       expect(err).to.not.exist()
@@ -117,19 +117,19 @@ describe('bitswap stats', () => {
   it('updates duplicate blocks counters', (done) => {
     const stats = bs.stat()
     stats.once('update', (stats) => {
-      expect(stats).to.have.property('blocksReceived', 4)
-      expect(stats).to.have.property('dataReceived', 192)
-      expect(stats).to.have.property('dupBlksReceived', 2)
-      expect(stats).to.have.property('dupDataReceived', 96)
-      expect(stats).to.have.property('blocksSent', 0)
-      expect(stats).to.have.property('dataSent', 0)
+      expect(stats.blocksReceived.eq(4)).to.be.true()
+      expect(stats.dataReceived.eq(192)).to.be.true()
+      expect(stats.dupBlksReceived.eq(2)).to.be.true()
+      expect(stats.dupDataReceived.eq(96)).to.be.true()
+      expect(stats.blocksSent.eq(0)).to.be.true()
+      expect(stats.dataSent.eq(0)).to.be.true()
       done()
     })
 
     const other = ids[1]
 
     const msg = new Message(false)
-    blocks.slice(0, 2).forEach((block) => msg.addBlock(block))
+    blocks.forEach((block) => msg.addBlock(block))
 
     bs._receiveMessage(other, msg, (err) => {
       expect(err).to.not.exist()
@@ -141,10 +141,6 @@ describe('bitswap stats', () => {
     let block
 
     before((done) => {
-      // parallel([
-      //   (cb) => libp2pNodes[0].dial(libp2pNodes[1].peerInfo, cb),
-      //   (cb) => libp2pNodes[1].dial(libp2pNodes[0].peerInfo, cb),
-      //   ], done)
       eachOf(
         libp2pNodes,
         (node, i, cb) => node.dial(libp2pNodes[(i + 1) % nodes.length].peerInfo, cb),
@@ -176,12 +172,12 @@ describe('bitswap stats', () => {
     it('updates stats on transfer', (done) => {
       const stats = bs.stat()
       stats.once('update', (stats) => {
-        expect(stats).to.have.property('blocksReceived', 4)
-        expect(stats).to.have.property('dataReceived', 192)
-        expect(stats).to.have.property('dupBlksReceived', 2)
-        expect(stats).to.have.property('dupDataReceived', 96)
-        expect(stats).to.have.property('blocksSent', 1)
-        expect(stats).to.have.property('dataSent', 48)
+        expect(stats.blocksReceived.eq(4)).to.be.true()
+        expect(stats.dataReceived.eq(192)).to.be.true()
+        expect(stats.dupBlksReceived.eq(2)).to.be.true()
+        expect(stats.dupDataReceived.eq(96)).to.be.true()
+        expect(stats.blocksSent.eq(1)).to.be.true()
+        expect(stats.dataSent.eq(48)).to.be.true()
         done()
       })
 

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -58,6 +58,7 @@ describe.only('bitswap stats', () => {
   it('has initial stats', () => {
     const stats = bs.stat().snapshot
     expect(stats).to.have.property('blocksReceived', 0)
+    expect(stats).to.have.property('dataReceived', 0)
     expect(stats).to.have.property('dupBlksReceived', 0)
     expect(stats).to.have.property('dupDataReceived', 0)
   })
@@ -69,6 +70,7 @@ describe.only('bitswap stats', () => {
       const stats = bs.stat()
       stats.once('update', (stats) => {
         expect(stats).to.have.property('blocksReceived', 2)
+        expect(stats).to.have.property('dataReceived', 96)
         expect(stats).to.have.property('dupBlksReceived', 0)
         expect(stats).to.have.property('dupDataReceived', 0)
         done()
@@ -89,6 +91,7 @@ describe.only('bitswap stats', () => {
     const stats = bs.stat()
     stats.once('update', (stats) => {
       expect(stats).to.have.property('blocksReceived', 4)
+      expect(stats).to.have.property('dataReceived', 192)
       expect(stats).to.have.property('dupBlksReceived', 2)
       expect(stats).to.have.property('dupDataReceived', 96)
       done()

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -68,7 +68,7 @@ describe('bitswap stats', () => {
 
   before(() => {
     bitswaps = nodes.map((node, i) => new Bitswap(libp2pNodes[i], repos[i].blocks, {
-      statsUpdateInterval: 100 // fast update interval for so tests run fast
+      statsComputeThrottleTimeout: 100 // fast update interval for so tests run fast
     }))
     bs = bitswaps[0]
   })

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -2,6 +2,8 @@
 'use strict'
 
 const map = require('async/map')
+const each = require('async/each')
+const eachOf = require('async/eachOf')
 const parallel = require('async/parallel')
 const _ = require('lodash')
 const chai = require('chai')
@@ -13,19 +15,21 @@ const Message = require('../src/types/message')
 const Bitswap = require('../src')
 
 const createTempRepo = require('./utils/create-temp-repo-nodejs')
-const mockLibp2pNode = require('./utils/mocks').mockLibp2pNode
+const createLibp2pNode = require('./utils/create-libp2p-node')
 const makeBlock = require('./utils/make-block')
 
-describe.only('bitswap stats', () => {
-  let repo
+describe('bitswap stats', () => {
+  const nodes = [0, 1]
+  let libp2pNodes
+  let repos
+  let bitswaps
+  let bs
   let blocks
   let ids
-  let bs
 
   before((done) => {
     parallel(
       {
-        repo: (cb) => createTempRepo(cb),
         blocks: (cb) => map(_.range(15), (i, cb) => makeBlock(cb), cb),
         ids: (cb) => map(_.range(2), (i, cb) => PeerId.create({bits: 1024}, cb), cb)
       },
@@ -34,7 +38,6 @@ describe.only('bitswap stats', () => {
           return done(err)
         }
 
-        repo = results.repo
         blocks = results.blocks
         ids = results.ids
 
@@ -43,17 +46,41 @@ describe.only('bitswap stats', () => {
     )
   })
 
-  before(() => {
-    bs = new Bitswap(mockLibp2pNode(), repo.blocks, {
-      statsUpdateInterval: 100 // fast update interval for so tests run fast
+  before((done) => {
+    // create 2 temp repos
+    map(nodes, (n, cb) => createTempRepo(cb), (err, _repos) => {
+      expect(err).to.not.exist()
+      repos = _repos
+      done()
     })
   })
 
+  before((done) => {
+    // create 2 libp2p nodes
+    map(nodes, (n, cb) => createLibp2pNode({
+      DHT: repos[n].datastore
+    }, cb), (err, _libp2pNodes) => {
+      expect(err).to.not.exist()
+      libp2pNodes = _libp2pNodes
+      done()
+    })
+  })
+
+  before(() => {
+    bitswaps = nodes.map((node, i) => new Bitswap(libp2pNodes[i], repos[i].blocks, {
+      statsUpdateInterval: 100 // fast update interval for so tests run fast
+    }))
+    bs = bitswaps[0]
+  })
+
+  // start the first bitswap
   before((done) => bs.start(done))
 
-  after((done) => bs.stop(done))
+  after((done) => each(bitswaps, (bs, cb) => bs.stop(cb), done))
 
-  after((done) => repo.teardown(done))
+  after((done) => each(repos, (repo, cb) => repo.teardown(cb), done))
+
+  after((done) => each(libp2pNodes, (n, cb) => n.stop(cb), done))
 
   it('has initial stats', () => {
     const stats = bs.stat().snapshot
@@ -61,39 +88,17 @@ describe.only('bitswap stats', () => {
     expect(stats).to.have.property('dataReceived', 0)
     expect(stats).to.have.property('dupBlksReceived', 0)
     expect(stats).to.have.property('dupDataReceived', 0)
+    expect(stats).to.have.property('dataSent', 0)
   })
 
   it('updates blocks received', (done) => {
-    bs.start((err) => {
-      expect(err).to.not.exist()
-
-      const stats = bs.stat()
-      stats.once('update', (stats) => {
-        expect(stats).to.have.property('blocksReceived', 2)
-        expect(stats).to.have.property('dataReceived', 96)
-        expect(stats).to.have.property('dupBlksReceived', 0)
-        expect(stats).to.have.property('dupDataReceived', 0)
-        done()
-      })
-
-      const other = ids[1]
-
-      const msg = new Message(false)
-      blocks.slice(0, 2).forEach((block) => msg.addBlock(block))
-
-      bs._receiveMessage(other, msg, (err) => {
-        expect(err).to.not.exist()
-      })
-    })
-  })
-
-  it('updates duplicate blocks counters', (done) => {
     const stats = bs.stat()
     stats.once('update', (stats) => {
-      expect(stats).to.have.property('blocksReceived', 4)
-      expect(stats).to.have.property('dataReceived', 192)
-      expect(stats).to.have.property('dupBlksReceived', 2)
-      expect(stats).to.have.property('dupDataReceived', 96)
+      expect(stats).to.have.property('blocksReceived', 2)
+      expect(stats).to.have.property('dataReceived', 96)
+      expect(stats).to.have.property('dupBlksReceived', 0)
+      expect(stats).to.have.property('dupDataReceived', 0)
+      expect(stats).to.have.property('dataSent', 0)
       done()
     })
 
@@ -104,6 +109,82 @@ describe.only('bitswap stats', () => {
 
     bs._receiveMessage(other, msg, (err) => {
       expect(err).to.not.exist()
+    })
+  })
+
+  it('updates duplicate blocks counters', (done) => {
+    const stats = bs.stat()
+    stats.once('update', (stats) => {
+      expect(stats).to.have.property('blocksReceived', 4)
+      expect(stats).to.have.property('dataReceived', 192)
+      expect(stats).to.have.property('dupBlksReceived', 2)
+      expect(stats).to.have.property('dupDataReceived', 96)
+      expect(stats).to.have.property('dataSent', 0)
+      done()
+    })
+
+    const other = ids[1]
+
+    const msg = new Message(false)
+    blocks.slice(0, 2).forEach((block) => msg.addBlock(block))
+
+    bs._receiveMessage(other, msg, (err) => {
+      expect(err).to.not.exist()
+    })
+  })
+
+  describe('connected to another bitswap', () => {
+    let bs2
+    let block
+
+    before((done) => {
+      // parallel([
+      //   (cb) => libp2pNodes[0].dial(libp2pNodes[1].peerInfo, cb),
+      //   (cb) => libp2pNodes[1].dial(libp2pNodes[0].peerInfo, cb),
+      //   ], done)
+      eachOf(
+        libp2pNodes,
+        (node, i, cb) => node.dial(libp2pNodes[(i + 1) % nodes.length].peerInfo, cb),
+        done)
+    })
+
+    before((done) => {
+      bs2 = bitswaps[1]
+      bs2.start(done)
+    })
+
+    after((done) => {
+      bs2.stop(done)
+    })
+
+    before((done) => {
+      makeBlock((err, _block) => {
+        expect(err).to.not.exist()
+        expect(_block).to.exist()
+        block = _block
+        done()
+      })
+    })
+
+    before((done) => {
+      bs.put(block, done)
+    })
+
+    it('updates stats on transfer', (done) => {
+      const stats = bs.stat()
+      stats.once('update', (stats) => {
+        expect(stats).to.have.property('blocksReceived', 4)
+        expect(stats).to.have.property('dataReceived', 192)
+        expect(stats).to.have.property('dupBlksReceived', 2)
+        expect(stats).to.have.property('dupDataReceived', 96)
+        expect(stats).to.have.property('dataSent', 60)
+        done()
+      })
+
+      bs2.get(block.cid, (err, _block) => {
+        expect(err).to.not.exist()
+        expect(_block).to.exist()
+      })
     })
   })
 })

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,4 +1,5 @@
 'use strict'
 
 require('./bitswap-mock-internals.js')
+require('./bitswap-stats.js')
 require('./decision-engine/decision-engine')

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,5 +1,4 @@
 'use strict'
 
 require('./bitswap-mock-internals.js')
-require('./bitswap-stats.js')
 require('./decision-engine/decision-engine')

--- a/test/node.js
+++ b/test/node.js
@@ -2,6 +2,7 @@
 
 require('./bitswap.js')
 require('./bitswap-mock-internals.js')
+require('./bitswap-stats.js')
 require('./decision-engine/decision-engine')
 require('./network/network.node.js')
 require('./network/gen-bitswap-network.node.js')

--- a/test/utils/mocks.js
+++ b/test/utils/mocks.js
@@ -13,6 +13,7 @@ const PeerBook = require('peer-book')
 const Node = require('./create-libp2p-node').bundle
 const os = require('os')
 const Repo = require('ipfs-repo')
+const EventEmitter = require('events')
 
 const Bitswap = require('../../src')
 
@@ -22,9 +23,10 @@ const Bitswap = require('../../src')
 exports.mockLibp2pNode = () => {
   const peerInfo = new PeerInfo(PeerId.createFromHexString('122019318b6e5e0cf93a2314bf01269a2cc23cd3dcd452d742cdb9379d8646f6e4a9'))
 
-  return {
+  return Object.assign(new EventEmitter(), {
     peerInfo: peerInfo,
     handle () {},
+    unhandle () {},
     contentRouting: {
       provide: (cid, callback) => callback(),
       findProviders: (cid, timeout, callback) => callback(null, [])
@@ -38,7 +40,7 @@ exports.mockLibp2pNode = () => {
       setMaxListeners () {}
     },
     peerBook: new PeerBook()
-  }
+  })
 }
 
 /*


### PR DESCRIPTION
Addresses #90 

- [x] make stats processing async
- [x] use BigNum for values
- [x] support all the stats as go-ipfs
- [x] make stats processing interval smart (debounce updates, threshold for queue size). Uses an adaptive algorithm to calculates next time when to run computations, a function of the current queue length.
- [x] average and stddev of frequency (use standard intervals like 1 min, 5 mins, 15 mins, for instance) 
- [x] enable / disable API