### PR TITLE
fix: reset batch size counter

### DIFF
--- a/src/decision-engine/index.js
+++ b/src/decision-engine/index.js
@@ -59,6 +59,7 @@ class DecisionEngine {
       if (size >= MAX_MESSAGE_SIZE ||
           // need to ensure the last remaining items get sent
           outstanding === 0) {
+        size = 0
         const nextBatch = batch.slice()
         batch = []
         this._sendSafeBlocks(peer, nextBatch, (err) => {

--- a/test/decision-engine/decision-engine.js
+++ b/test/decision-engine/decision-engine.js
@@ -216,7 +216,11 @@ describe('Engine', () => {
     })
 
     const net = mockNetwork(5, (res) => {
-      expect(res.messages).to.have.length(5)
+      res.messages.forEach((message) => {
+        // The batch size is big enough to hold two blocks, so every
+        // message should contain two blocks
+        expect(message[1].blocks.size).to.eql(2)
+      })
       done()
     })
 


### PR DESCRIPTION
When a batch of blocks was sent, the counter for the calculating
the size wasn't reset. After the initial batch, every message was
sent individually, which lead to a performance bottleneck. With
this change receiving larger files (> 2MiB) is about 30% faster.