### PR TITLE
chore: add module Lead Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 > JavaScript implementation of the Bitswap 'data exchange' protocol used by IPFS
 
+## Lead Maintainer
+
+[Volker Mische](https://github.com/vmx)
+
 ## Table of Contents
 
 - [Install](#install)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ipfs-bitswap",
   "version": "0.20.1",
   "description": "Node.js implementation of the Bitswap data exchange protocol used by IPFS",
+  "leadMaintainer": "Volker Mische <volker.mische@gmail.com>",
   "main": "src/index.js",
   "browser": {
     "./test/utils/create-libp2p-node": false,
@@ -31,7 +32,6 @@
     "p2p",
     "exchange"
   ],
-  "author": "Friedel Ziegelmayer <dignifiedquire@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/ipfs/js-ipfs-bitswap/issues"


### PR DESCRIPTION
The Guidelines for the InterPlanetary JavaScript Projects [1] specify
that there is one Lead Maintainer for every module. This commit add
that information to the repository.

[1]: https://github.com/ipfs/community/blob/master/js-code-guidelines.md

Closes #177.