### PR TITLE
feat: change bitswapLedgerForPeer output format

### DIFF
--- a/src/decision-engine/index.js
+++ b/src/decision-engine/index.js
@@ -143,7 +143,7 @@ class DecisionEngine {
       return null
     }
     return {
-      peer: ledger.partner.toB58String(),
+      peer: ledger.partner.toPrint(),
       value: ledger.debtRatio(),
       sent: ledger.accounting.bytesSent,
       recv: ledger.accounting.bytesRecv,

--- a/test/bitswap-mock-internals.js
+++ b/test/bitswap-mock-internals.js
@@ -78,7 +78,7 @@ describe('bitswap with mocks', function () {
             expect(blocks[1].data).to.eql(b2.data)
 
             const ledger = bs.ledgerForPeer(other)
-            expect(ledger.peer).to.equal(other.toB58String())
+            expect(ledger.peer).to.equal(other.toPrint())
             expect(ledger.value).to.equal(0)
             expect(ledger.sent).to.equal(0)
             expect(ledger.recv).to.equal(96)


### PR DESCRIPTION
Use toPrint for the peer id output

As discussed in the last pr #179 we keep the lower case json output but switch to the correct peer id representation.