### PR TITLE
fix: stringify to hex

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -34,7 +34,7 @@ class Notifications extends EventEmitter {
    * @return {void}
    */
   hasBlock (block) {
-    const str = `block:${block.cid.buffer.toString()}`
+    const str = `block:${block.cid.buffer.toString('hex')}`
     this._log(str)
     this.emit(str, block)
   }
@@ -49,7 +49,7 @@ class Notifications extends EventEmitter {
    * @returns {void}
    */
   wantBlock (cid, onBlock, onUnwant) {
-    const cidStr = cid.buffer.toString()
+    const cidStr = cid.buffer.toString('hex')
     this._log(`wantBlock:${cidStr}`)
 
     this._unwantListeners[cidStr] = () => {
@@ -80,7 +80,7 @@ class Notifications extends EventEmitter {
    * @returns {void}
    */
   unwantBlock (cid) {
-    const str = `unwant:${cid.buffer.toString()}`
+    const str = `unwant:${cid.buffer.toString('hex')}`
     this._log(str)
     this.emit(str)
   }

--- a/src/types/message/index.js
+++ b/src/types/message/index.js
@@ -28,7 +28,7 @@ class BitswapMessage {
 
   addEntry (cid, priority, cancel) {
     assert(cid && CID.isCID(cid), 'must be a valid cid')
-    const cidStr = cid.buffer.toString()
+    const cidStr = cid.buffer.toString('hex')
 
     const entry = this.wantlist.get(cidStr)
 
@@ -42,13 +42,13 @@ class BitswapMessage {
 
   addBlock (block) {
     assert(Block.isBlock(block), 'must be a valid cid')
-    const cidStr = block.cid.buffer.toString()
+    const cidStr = block.cid.buffer.toString('hex')
     this.blocks.set(cidStr, block)
   }
 
   cancel (cid) {
     assert(CID.isCID(cid), 'must be a valid cid')
-    const cidStr = cid.buffer.toString()
+    const cidStr = cid.buffer.toString('hex')
     this.wantlist.delete(cidStr)
     this.addEntry(cid, 0, true)
   }

--- a/src/types/wantlist/index.js
+++ b/src/types/wantlist/index.js
@@ -14,7 +14,7 @@ class Wantlist {
   }
 
   add (cid, priority) {
-    const cidStr = cid.buffer.toString()
+    const cidStr = cid.buffer.toString('hex')
     const entry = this.set.get(cidStr)
 
     if (entry) {
@@ -29,7 +29,7 @@ class Wantlist {
   }
 
   remove (cid) {
-    const cidStr = cid.buffer.toString()
+    const cidStr = cid.buffer.toString('hex')
     const entry = this.set.get(cidStr)
 
     if (!entry) {
@@ -68,7 +68,7 @@ class Wantlist {
   }
 
   contains (cid) {
-    const cidStr = cid.buffer.toString()
+    const cidStr = cid.buffer.toString('hex')
     return this.set.get(cidStr)
   }
 }

--- a/test/bitswap-mock-internals.js
+++ b/test/bitswap-mock-internals.js
@@ -107,8 +107,8 @@ describe('bitswap with mocks', function () {
 
           const wl = bs.wantlistForPeer(other)
 
-          expect(wl.has(b1.cid.buffer.toString())).to.eql(true)
-          expect(wl.has(b2.cid.buffer.toString())).to.eql(true)
+          expect(wl.has(b1.cid.buffer.toString('hex'))).to.eql(true)
+          expect(wl.has(b2.cid.buffer.toString('hex'))).to.eql(true)
 
           done()
         })

--- a/test/notifications.spec.js
+++ b/test/notifications.spec.js
@@ -34,7 +34,7 @@ describe('Notifications', () => {
   it('hasBlock', (done) => {
     const n = new Notifications(peerId)
     const b = blocks[0]
-    n.once(`block:${b.cid.buffer.toString()}`, (block) => {
+    n.once(`block:${b.cid.buffer.toString('hex')}`, (block) => {
       expect(b).to.eql(block)
       done()
     })

--- a/test/types/message.spec.js
+++ b/test/types/message.spec.js
@@ -92,15 +92,15 @@ describe('BitswapMessage', () => {
       expect(msg.full).to.equal(true)
       expect(Array.from(msg.wantlist))
         .to.eql([[
-          cid0.buffer.toString(),
+          cid0.buffer.toString('hex'),
           new BitswapMessage.Entry(cid0, 0, false)
         ]])
 
       expect(
         Array.from(msg.blocks).map((b) => [b[0], b[1].data])
       ).to.eql([
-        [cid1.buffer.toString(), b1.data],
-        [cid2.buffer.toString(), b2.data]
+        [cid1.buffer.toString('hex'), b1.data],
+        [cid2.buffer.toString('hex'), b2.data]
       ])
 
       done()
@@ -137,15 +137,15 @@ describe('BitswapMessage', () => {
       expect(msg.full).to.equal(true)
       expect(Array.from(msg.wantlist))
         .to.eql([[
-          cid0.buffer.toString(),
+          cid0.buffer.toString('hex'),
           new BitswapMessage.Entry(cid0, 0, false)
         ]])
 
       expect(
         Array.from(msg.blocks).map((b) => [b[0], b[1].data])
       ).to.eql([
-        [cid1.buffer.toString(), b1.data],
-        [cid2.buffer.toString(), b2.data]
+        [cid1.buffer.toString('hex'), b1.data],
+        [cid2.buffer.toString('hex'), b2.data]
       ])
 
       done()

--- a/test/types/wantlist.spec.js
+++ b/test/types/wantlist.spec.js
@@ -86,7 +86,7 @@ describe('Wantlist', () => {
     expect(
       Array.from(wm.entries())
     ).to.be.eql([[
-      b.cid.buffer.toString(),
+      b.cid.buffer.toString('hex'),
       new Wantlist.Entry(b.cid, 2)
     ]])
   })
@@ -101,8 +101,8 @@ describe('Wantlist', () => {
     expect(
       Array.from(wm.sortedEntries())
     ).to.be.eql([
-      [b1.cid.buffer.toString(), new Wantlist.Entry(b1.cid, 1)],
-      [b2.cid.buffer.toString(), new Wantlist.Entry(b2.cid, 1)]
+      [b1.cid.buffer.toString('hex'), new Wantlist.Entry(b1.cid, 1)],
+      [b2.cid.buffer.toString('hex'), new Wantlist.Entry(b2.cid, 1)]
     ])
   })
 
@@ -126,7 +126,7 @@ describe('Wantlist', () => {
       expect(
         Array.from(wm.entries())
       ).to.be.eql([[
-        cid.buffer.toString(),
+        cid.buffer.toString('hex'),
         new Wantlist.Entry(cid, 2)
       ]])
       done()


### PR DESCRIPTION
Calling `toString()` on a buffer might lead to the same result
although the buffers are different. Example:

    $ node
    > const buf1 = Buffer.from('15603533e990dfde', 'hex')
    undefined
    > const buf2 = Buffer.from('15603533e990dfe0', 'hex')
    undefined
    > buf1.toString()
    '\u0015`53���'
    > buf2.toString()
    '\u0015`53���'
    > buf1.toString() === buf2.toString()
    true
    > buf1.toString('hex') === buf2.toString('hex')
    false

Currently CIDs are stored internally with their `toString()` representation.
This could fail as different CIDs could end up with the same representation.
The fix is to use the hex representation instead.

Closes #186.

BREAKING CHANGE: emitted keys change

Bitswap has an event emitter which emits events when a block is received
and when a block is not wanted anymore. These events contain a string
representation of the CID. This representation changes with this commit.

Though practically it shouldn't have any impact on any system, except if
you have hard-coded specific CIDs.