### PR TITLE
refactor: default to CID v1 and encode with base32

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "bignumber.js": "^8.0.1",
-    "cids": "~0.5.5",
+    "cids": "github:multiformats/js-cid#refactor/cidv1base32-default",
     "debug": "^4.1.0",
     "ipfs-block": "~0.8.0",
     "just-debounce-it": "^1.1.0",


### PR DESCRIPTION
BREAKING CHANGE: Any v1 CIDs created and returned by this module now use base32 encoding by default when stringified.

Depends on:

* [ ] https://github.com/multiformats/js-cid/pull/73