### PR TITLE
fix: base encode CIDs before logging or emitting them

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -34,7 +34,7 @@ class Notifications extends EventEmitter {
    * @return {void}
    */
   hasBlock (block) {
-    const str = `block:${block.cid.buffer.toString()}`
+    const str = `block:${block.cid}`
     this._log(str)
     this.emit(str, block)
   }
@@ -49,7 +49,7 @@ class Notifications extends EventEmitter {
    * @returns {void}
    */
   wantBlock (cid, onBlock, onUnwant) {
-    const cidStr = cid.buffer.toString()
+    const cidStr = cid.toString()
     this._log(`wantBlock:${cidStr}`)
 
     this._unwantListeners[cidStr] = () => {
@@ -80,7 +80,7 @@ class Notifications extends EventEmitter {
    * @returns {void}
    */
   unwantBlock (cid) {
-    const str = `unwant:${cid.buffer.toString()}`
+    const str = `unwant:${cid}`
     this._log(str)
     this.emit(str)
   }

--- a/test/notifications.spec.js
+++ b/test/notifications.spec.js
@@ -34,7 +34,7 @@ describe('Notifications', () => {
   it('hasBlock', (done) => {
     const n = new Notifications(peerId)
     const b = blocks[0]
-    n.once(`block:${b.cid.buffer.toString()}`, (block) => {
+    n.once(`block:${b.cid}`, (block) => {
       expect(b).to.eql(block)
       done()
     })


### PR DESCRIPTION
At the moment we turn the CID buffers into UTF8 encoded strings before logging them and emitting events with that string in the name.  This can result in Zalgo leaking into the terminal:

```console
bitswap:notif:QmZoFh73 wantBlock: å&���+�
                                           2�@��Hfä4���┼�▒3��]� +0└⎽
  ␉␋├⎽┬▒⎻:┬▒┼├:Q└Z⎺F␤73 ▒␍␍␋┼± ├⎺ ┬┌ +0└⎽
  ┌␋␉⎻2⎻:␍␤├:Q└Z⎺F␤73 °␋┼␍P⎼⎺┴␋␍␊⎼⎽ Q└␉1≥Q⎺7RK▒␍±␌8␍4RFFBVP┘134N␌2│FEPP5┬S␋M␊GAAT4 +1└⎽
  ┌␋␉⎻2⎻:␍␤├:⎻⎼⎺┴␋␍␊⎼⎽:Q└Z⎺F␤73 ±␊├P⎼⎺┴␋␍␊⎼⎽ Q└␉1≥Q⎺7RK▒␍±␌8␍4RFFBVP┘134N␌2│FEPP5┬S␋M␊GAAT4 +1└⎽
  ␉␋├⎽┬▒⎻:┼⎺├␋°:Q└Z⎺F␤73 ┬▒┼├B┌⎺␌┐: �◆+�W���␌��#�����␋��4�Ɔ┌# +1└⎽
  ␉␋├⎽┬▒⎻:┬▒┼├:Q└Z⎺F␤73 ▒␍␍␋┼± ├⎺ ┬┌ +1└⎽
  ┌␋␉⎻2⎻:␍␤├:Q└Z⎺F␤73 °␋┼␍P⎼⎺┴␋␍␊⎼⎽ Q└U4␌K▒Q␊┤R␌│YK┬HYFSGZCF≤B1─␊┤L␌X┴Y┘┬┼┐AUT└KAS +0└⎽
  ┌␋␉⎻2⎻:␍␤├:⎻⎼⎺┴␋␍␊⎼⎽:Q└Z⎺F␤73 ±␊├P⎼⎺┴␋␍␊⎼⎽ 
```

This PR calls `cid.toBaseEncodedString()` instead of `cid.buffer.toString()`.

May be a breaking change as the names of events emitted by this module are based on `cid.buffer.toString()`.