### PR TITLE
feat: use async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,9 +76,11 @@
     "moving-average": "^1.0.0",
     "multicodec": "~0.5.0",
     "multihashing-async": "~0.5.1",
+    "promisify-es6": "^1.0.3",
     "protons": "^1.0.1",
     "pull-length-prefixed": "^1.3.1",
     "pull-stream": "^3.6.9",
+    "typical": "^4.0.0",
     "varint-decoder": "~0.1.1"
   },
   "pre-push": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,7 @@
 'use strict'
 
 const waterfall = require('async/waterfall')
-const reject = require('async/reject')
 const each = require('async/each')
-const series = require('async/series')
 const nextTick = require('async/nextTick')
 const promisify = require('promisify-es6')
 const typical = require('typical')
@@ -319,7 +317,7 @@ class Bitswap {
   /**
    * Get the current list of wants.
    *
-   * @returns {Iterator<WantlistEntry>}
+   * @returns {Iterator.<WantlistEntry>}
    */
   getWantlist () {
     return this.wm.wantlist.entries()
@@ -328,7 +326,7 @@ class Bitswap {
   /**
    * Get the current list of partners.
    *
-   * @returns {Array<PeerId>}
+   * @returns {Array.<PeerId>}
    */
   peers () {
     return this.engine.peers()
@@ -346,32 +344,25 @@ class Bitswap {
   /**
    * Start the bitswap node.
    *
-   * @param {function(Error)} callback
-   *
-   * @returns {void}
+   * @returns {Promise}
    */
-  start (callback) {
-    series([
-      (cb) => this.wm.start(cb),
-      (cb) => this.network.start(cb),
-      (cb) => this.engine.start(cb)
-    ], callback)
+  async start () {
+    await promisify(this.wm.start.bind(this.wm))()
+    await promisify(this.network.start.bind(this.network))()
+    await promisify(this.engine.start.bind(this.engine))()
   }
 
   /**
    * Stop the bitswap node.
    *
-   * @param {function(Error)} callback
-   *
-   * @returns {void}
+   * @returns {Promise}
    */
-  stop (callback) {
+  async stop () {
     this._stats.stop()
-    series([
-      (cb) => this.wm.stop(cb),
-      (cb) => this.network.stop(cb),
-      (cb) => this.engine.stop(cb)
-    ], callback)
+
+    await promisify(this.wm.stop.bind(this.wm))()
+    await promisify(this.network.stop.bind(this.network))()
+    await promisify(this.engine.stop.bind(this.engine))()
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,14 +4,15 @@ const waterfall = require('async/waterfall')
 const reject = require('async/reject')
 const each = require('async/each')
 const series = require('async/series')
-const map = require('async/map')
 const nextTick = require('async/nextTick')
+const promisify = require('promisify-es6')
+const typical = require('typical')
 
 const WantManager = require('./want-manager')
 const Network = require('./network')
 const DecisionEngine = require('./decision-engine')
 const Notifications = require('./notifications')
-const logger = require('./utils').logger
+const { logger, extendIterator } = require('./utils')
 const Stats = require('./stats')
 
 const defaultOptions = {
@@ -162,6 +163,14 @@ class Bitswap {
     })
   }
 
+  _findAndConnect (cid) {
+    if (this.promptNetwork) {
+      this.network.findAndConnect(cid, (err) => {
+        if (err) this._log.error(err)
+      })
+    }
+  }
+
   enableStats () {
     this._stats.enable()
   }
@@ -194,88 +203,72 @@ class Bitswap {
    * Fetch a given block by cid. If the block is in the local
    * blockstore it is returned, otherwise the block is added to the wantlist and returned once another node sends it to us.
    *
-   * @param {CID} cid
-   * @param {function(Error, Block)} callback
-   * @returns {void}
+   * @param {CID} cid - The CID of the block that should be retrieved.
+   * @param {Object} options
+   * @param {boolean} options.promptNetwork - Option whether to promptNetwork or not
+   * @returns {Promise.<Object>} - Returns a promise with a block corresponding with the given `cid`.
    */
-  get (cid, callback) {
-    this.getMany([cid], (err, blocks) => {
-      if (err) {
-        return callback(err)
-      }
+  async get (cid, options) {
+    const optionsCopy = Object.assign({}, options)
 
-      if (blocks && blocks.length > 0) {
-        callback(null, blocks[0])
-      } else {
-        // when a unwant happens
-        callback()
+    optionsCopy.promptNetwork = optionsCopy.promptNetwork || true
+
+    const getFromOutside = (cid) => {
+      return new Promise((resolve) => {
+        this.wm.wantBlocks([cid])
+
+        this.notifications.wantBlock(
+          cid,
+          // called on block receive
+          (block) => {
+            this.wm.cancelWants([cid])
+            resolve(block)
+          },
+          // called on unwant
+          () => {
+            this.wm.cancelWants([cid])
+            resolve(undefined)
+          }
+        )
+      })
+    }
+
+    if (await promisify(this.blockstore.has)(cid)) {
+      return promisify(this.blockstore.get)(cid)
+    } else {
+      if (optionsCopy.promptNetwork) {
+        this._findAndConnect(cid)
       }
-    })
+      return getFromOutside(cid)
+    }
   }
 
   /**
    * Fetch a a list of blocks by cid. If the blocks are in the local
    * blockstore they are returned, otherwise the blocks are added to the wantlist and returned once another node sends them to us.
    *
-   * @param {Array<CID>} cids
-   * @param {function(Error, Blocks)} callback
-   * @returns {void}
+   * @param {Iterable.<CID>} cids
+   * @returns {Iterable.<Promise.<Object>>}
    */
-  getMany (cids, callback) {
-    let pendingStart = cids.length
-    const wantList = []
-    let promptedNetwork = false
-
-    const getFromOutside = (cid, cb) => {
-      wantList.push(cid)
-
-      this.notifications.wantBlock(
-        cid,
-        // called on block receive
-        (block) => {
-          this.wm.cancelWants([cid])
-          cb(null, block)
-        },
-        // called on unwant
-        () => {
-          this.wm.cancelWants([cid])
-          cb(null, undefined)
-        }
-      )
-
-      if (!pendingStart) {
-        this.wm.wantBlocks(wantList)
-      }
+  getMany (cids) {
+    if (!typical.isIterable(cids) || typical.isString(cids) ||
+        Buffer.isBuffer(cids)) {
+      throw new Error('`cids` must be an iterable of CIDs')
     }
 
-    map(cids, (cid, cb) => {
-      waterfall(
-        [
-          (cb) => this.blockstore.has(cid, cb),
-          (has, cb) => {
-            pendingStart--
-            if (has) {
-              if (!pendingStart) {
-                this.wm.wantBlocks(wantList)
-              }
-              return this.blockstore.get(cid, cb)
-            }
+    const generator = async function * () {
+      let promptNetwork = true
+      for await (const cid of cids) {
+        if (promptNetwork) {
+          yield this.get(cid, { promptNetwork: true })
+          promptNetwork = false
+        } else {
+          yield this.get(cid, { promptNetwork: false })
+        }
+      }
+    }.bind(this)
 
-            if (!promptedNetwork) {
-              promptedNetwork = true
-              this.network.findAndConnect(cids[0], (err) => {
-                if (err) {
-                  this._log.error(err)
-                }
-              })
-            }
-
-            // we don't have the block here
-            getFromOutside(cid, cb)
-          }
-        ],
-        cb)
-    }, callback)
+    return extendIterator(generator())
   }
 
   // removes the given cids from the wantlist independent of any ref counts

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ class Bitswap {
           return nextTick(cb)
         }
 
-        this._putBlock(block, cb)
+        this.put(block).then(() => cb())
       }
     ], callback)
   }
@@ -145,30 +145,10 @@ class Bitswap {
     this._stats.disconnected(peerId)
   }
 
-  _putBlock (block, callback) {
-    this.blockstore.put(block, (err) => {
-      if (err) {
-        return callback(err)
-      }
-
-      this.notifications.hasBlock(block)
-      this.network.provide(block.cid, (err) => {
-        if (err) {
-          this._log.error('Failed to provide: %s', err.message)
-        }
-      })
-
-      this.engine.receivedBlocks([block.cid])
-      callback()
-    })
-  }
-
   _findAndConnect (cid) {
-    if (this.promptNetwork) {
-      this.network.findAndConnect(cid, (err) => {
-        if (err) this._log.error(err)
-      })
-    }
+    this.network.findAndConnect(cid, (err) => {
+      if (err) this._log.error(err)
+    })
   }
 
   enableStats () {
@@ -293,55 +273,47 @@ class Bitswap {
    * Put the given block to the underlying blockstore and
    * send it to nodes that have it in their wantlist.
    *
-   * @param {Block} block
-   * @param {function(Error)} callback
-   * @returns {void}
+   * @param {Block} block - Block that should be inserted.
+   * @returns {Promise.<CID>} - Returns the CID of the serialized IPLD Nodes.
    */
-  put (block, callback) {
+  async put (block) {
     this._log('putting block')
 
-    waterfall([
-      (cb) => this.blockstore.has(block.cid, cb),
-      (has, cb) => {
-        if (has) {
-          return nextTick(cb)
-        }
+    const has = await promisify(this.blockstore.has)(block.cid)
+    if (!has) {
+      await promisify(this.blockstore.put)(block)
+      this.notifications.hasBlock(block)
+      this.network.provide(block.cid, (err) => {
+        if (err) this._log.error('Failed to provide: %s', err.message)
+      })
+      this.engine.receivedBlocks([block.cid])
+    }
 
-        this._putBlock(block, cb)
-      }
-    ], callback)
+    return block.cid
   }
 
   /**
    * Put the given blocks to the underlying blockstore and
    * send it to nodes that have it them their wantlist.
    *
-   * @param {Array<Block>} blocks
-   * @param {function(Error)} callback
-   * @returns {void}
+   * @param {Iterable.<Block>} blocks
+   * @returns {Iterable.<Promise.<CID>>} - Returns an async iterator with the CIDs of the blocks inserted
    */
-  putMany (blocks, callback) {
-    waterfall([
-      (cb) => reject(blocks, (b, cb) => {
-        this.blockstore.has(b.cid, cb)
-      }, cb),
-      (newBlocks, cb) => this.blockstore.putMany(newBlocks, (err) => {
-        if (err) {
-          return cb(err)
-        }
+  putMany (blocks) {
+    if (!typical.isIterable(blocks)) {
+      throw new Error('`blocks` must be an iterable')
+    }
 
-        newBlocks.forEach((block) => {
-          this.notifications.hasBlock(block)
-          this.engine.receivedBlocks([block.cid])
-          this.network.provide(block.cid, (err) => {
-            if (err) {
-              this._log.error('Failed to provide: %s', err.message)
-            }
-          })
-        })
-        cb()
-      })
-    ], callback)
+    const generator = async function * () {
+      for await (const block of blocks) {
+        const has = await promisify(this.blockstore.has)(block.cid)
+        if (!has) {
+          yield this.put(block)
+        }
+      }
+    }.bind(this)
+
+    return extendIterator(generator())
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,7 @@ class Bitswap {
   }
 
   _findAndConnect (cid) {
-    this.network.findAndConnect(cid, (err) => {
+    this.network.findAndConnect(cid).catch((err) => {
       if (err) this._log.error(err)
     })
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,11 +80,41 @@ const sortBy = (fn, list) => {
   })
 }
 
+const first = async (iterator) => {
+  for await (const value of iterator) {
+    return value
+  }
+}
+
+const last = async (iterator) => {
+  let value
+  for await (value of iterator) {
+    // Intentionally empty
+  }
+  return value
+}
+
+const all = async (iterator) => {
+  const values = []
+  for await (const value of iterator) {
+    values.push(value)
+  }
+  return values
+}
+
+const extendIterator = (iterator) => {
+  iterator.first = () => first(iterator)
+  iterator.last = () => last(iterator)
+  iterator.all = () => all(iterator)
+  return iterator
+}
+
 module.exports = {
   logger,
   includesWith,
   uniqWith,
   groupBy,
   pullAllWith,
-  sortBy
+  sortBy,
+  extendIterator
 }

--- a/src/want-manager/msg-queue.js
+++ b/src/want-manager/msg-queue.js
@@ -57,7 +57,6 @@ module.exports = class MsgQueue {
       })
     } catch (err) {
       this._log.error('cant connect to peer %s: %s', this.peerId.toB58String(), err.message)
-      return
     }
   }
 }

--- a/src/want-manager/msg-queue.js
+++ b/src/want-manager/msg-queue.js
@@ -46,19 +46,18 @@ module.exports = class MsgQueue {
     this.addMessage(msg)
   }
 
-  send (msg) {
-    this.network.connectTo(this.peerId, (err) => {
-      if (err) {
-        this._log.error('cant connect to peer %s: %s', this.peerId.toB58String(), err.message)
-        return
-      }
-
+  async send (msg) {
+    try {
+      await this.network.connectTo(this.peerId)
       this._log('sending message')
       this.network.sendMessage(this.peerId, msg, (err) => {
         if (err) {
           this._log.error('send error: %s', err.message)
         }
       })
-    })
+    } catch (err) {
+      this._log.error('cant connect to peer %s: %s', this.peerId.toB58String(), err.message)
+      return
+    }
   }
 }

--- a/test/bitswap-mock-internals.js
+++ b/test/bitswap-mock-internals.js
@@ -249,12 +249,10 @@ describe('bitswap with mocks', function () {
       let bs2
 
       const n1 = {
-        connectTo (id, cb) {
-          let err
+        connectTo (id) {
           if (id.toHexString() !== other.toHexString()) {
-            err = new Error('unknown peer')
+            throw new Error('unknown peer')
           }
-          setImmediate(() => cb(err))
         },
         sendMessage (id, msg, cb) {
           if (id.toHexString() === other.toHexString()) {
@@ -278,11 +276,9 @@ describe('bitswap with mocks', function () {
       }
       const n2 = {
         connectTo (id, cb) {
-          let err
           if (id.toHexString() !== me.toHexString()) {
-            err = new Error('unkown peer')
+            throw new Error('unknown peer')
           }
-          setImmediate(() => cb(err))
         },
         sendMessage (id, msg, cb) {
           if (id.toHexString() === me.toHexString()) {
@@ -305,7 +301,6 @@ describe('bitswap with mocks', function () {
         }
       }
 
-      // Do not remove semi-colon. Will break the test.
       ;(async () => {
         // Create and start bs1
         bs1 = new Bitswap(mockLibp2pNode(), repo.blocks)

--- a/test/bitswap-mock-internals.js
+++ b/test/bitswap-mock-internals.js
@@ -55,9 +55,11 @@ describe('bitswap with mocks', function () {
 
   describe('receive message', () => {
     it('simple block message', (done) => {
-      const bs = new Bitswap(mockLibp2pNode(), repo.blocks)
-      bs.start((err) => {
-        expect(err).to.not.exist()
+      (async () => {
+        const bs = new Bitswap(mockLibp2pNode(), repo.blocks)
+        await bs.start().catch((err) => {
+          expect(err).to.not.exist()
+        })
 
         const other = ids[1]
 
@@ -86,13 +88,16 @@ describe('bitswap with mocks', function () {
             done()
           })
         })
-      })
+      })()
     })
 
     it('simple want message', (done) => {
-      const bs = new Bitswap(mockLibp2pNode(), repo.blocks)
-      bs.start((err) => {
-        expect(err).to.not.exist()
+      (async () => {
+        const bs = new Bitswap(mockLibp2pNode(), repo.blocks)
+        await bs.start().catch((err) => {
+          expect(err).to.not.exist()
+        })
+
         const other = ids[1]
         const b1 = blocks[0]
         const b2 = blocks[1]
@@ -112,7 +117,7 @@ describe('bitswap with mocks', function () {
 
           done()
         })
-      })
+      })()
     })
 
     it('multi peer', function (done) {
@@ -122,8 +127,8 @@ describe('bitswap with mocks', function () {
       let others
       let blocks
 
-      bs.start((err) => {
-        expect(err).to.not.exist()
+      (async () => {
+        await bs.start()
 
         parallel([
           (cb) => map(_.range(5), (i, cb) => PeerId.create({ bits: 512 }, cb), cb),
@@ -155,7 +160,7 @@ describe('bitswap with mocks', function () {
             }, done)
           })
         }
-      })
+      })()
     })
   })
 
@@ -223,7 +228,7 @@ describe('bitswap with mocks', function () {
         bs.network = net
         bs.wm.network = net
         bs.engine.network = net
-        await promisify(bs.start.bind(bs))()
+        await bs.start()
         bs.get(block.cid).then((res) => {
           expect(res).to.eql(block)
           finish(2)
@@ -305,13 +310,13 @@ describe('bitswap with mocks', function () {
         // Create and start bs1
         bs1 = new Bitswap(mockLibp2pNode(), repo.blocks)
         applyNetwork(bs1, n1)
-        await promisify(bs1.start.bind(bs1))()
+        await bs1.start()
 
         // Create and start bs2
         const repo2 = await promisify(createTempRepo)()
         bs2 = new Bitswap(mockLibp2pNode(), repo2.blocks)
         applyNetwork(bs2, n2)
-        await promisify(bs2.start.bind(bs2))()
+        await bs2.start()
 
         bs1._onPeerConnected(other)
         bs2._onPeerConnected(me)
@@ -354,7 +359,7 @@ describe('bitswap with mocks', function () {
     it('removes blocks that are wanted multiple times', (done) => {
       (async () => {
         const bs = new Bitswap(mockLibp2pNode(), repo.blocks)
-        await promisify(bs.start.bind(bs))()
+        await bs.start()
 
         const b = blocks[12]
         Promise.all([

--- a/test/bitswap-mock-internals.js
+++ b/test/bitswap-mock-internals.js
@@ -267,8 +267,8 @@ describe('bitswap with mocks', function () {
         stop (callback) {
           setImmediate(() => callback())
         },
-        findAndConnect (cid, callback) {
-          setImmediate(() => callback())
+        findAndConnect (cid) {
+          return new Promise(() => {})
         },
         provide (cid, callback) {
           setImmediate(() => callback())
@@ -293,8 +293,8 @@ describe('bitswap with mocks', function () {
         stop (callback) {
           setImmediate(() => callback())
         },
-        findAndConnect (cid, callback) {
-          setImmediate(() => callback())
+        findAndConnect (cid) {
+          return new Promise(() => {})
         },
         provide (cid, callback) {
           setImmediate(() => callback())

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -231,10 +231,11 @@ describe('bitswap stats', () => {
         finish()
       })
 
-      bs2.get(block.cid, (err, block) => {
-        expect(err).to.not.exist()
+      bs2.get(block.cid).then(() => {
         expect(block).to.exist()
         finish()
+      }).catch((err) => {
+        expect(err).to.not.exist()
       })
     })
 

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -90,9 +90,11 @@ describe('bitswap stats', () => {
   })
 
   // start the first bitswap
-  before((done) => bs.start(done))
+  before((done) => {
+    bs.start().then(() => done())
+  })
 
-  after((done) => each(bitswaps, (bs, cb) => bs.stop(cb), done))
+  after((done) => each(bitswaps, (bs, cb) => bs.stop().then(() => cb()), done))
 
   after((done) => each(repos, (repo, cb) => repo.teardown(cb), done))
 
@@ -196,11 +198,11 @@ describe('bitswap stats', () => {
 
     before((done) => {
       bs2 = bitswaps[1]
-      bs2.start(done)
+      bs2.start().then(() => done())
     })
 
     after((done) => {
-      bs2.stop(done)
+      bs2.stop().then(() => done())
     })
 
     before((done) => {

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -212,8 +212,8 @@ describe('bitswap stats', () => {
       })
     })
 
-    before((done) => {
-      bs.put(block, done)
+    before(async () => {
+      await bs.put(block)
     })
 
     it('updates stats on transfer', (done) => {

--- a/test/bitswap.js
+++ b/test/bitswap.js
@@ -30,7 +30,7 @@ function createThing (dht, callback) {
     },
     (repo, libp2pNode, cb) => {
       const bitswap = new Bitswap(libp2pNode, repo.blocks)
-      bitswap.start((err) => cb(err, repo, libp2pNode, bitswap))
+      bitswap.start().then((err) => cb(err, repo, libp2pNode, bitswap))
     }
   ], (err, repo, libp2pNode, bitswap) => {
     expect(err).to.not.exist()
@@ -64,7 +64,7 @@ describe('bitswap without DHT', function () {
   after((done) => {
     each(nodes, (node, cb) => {
       series([
-        (cb) => node.bitswap.stop(cb),
+        (cb) => node.bitswap.stop().then(() => cb()),
         (cb) => node.libp2pNode.stop(cb),
         (cb) => node.repo.teardown(cb)
       ], cb)
@@ -120,7 +120,7 @@ describe('bitswap with DHT', function () {
   after((done) => {
     each(nodes, (node, cb) => {
       series([
-        (cb) => node.bitswap.stop(cb),
+        (cb) => node.bitswap.stop().then(() => cb()),
         (cb) => node.libp2pNode.stop(cb),
         (cb) => node.repo.teardown(cb)
       ], cb)

--- a/test/bitswap.js
+++ b/test/bitswap.js
@@ -84,7 +84,6 @@ describe('bitswap without DHT', function () {
 
       const block = await promisify(makeBlock)()
       await nodes[2].bitswap.put(block)
-      // await promisify(nodes[2].bitswap.put.bind(nodes[2].bitswap))(block)
 
       nodes[0].bitswap.get(block.cid).then((block) => {
         expect(block).to.not.exist()

--- a/test/bitswap.js
+++ b/test/bitswap.js
@@ -83,7 +83,8 @@ describe('bitswap without DHT', function () {
       const finish = orderedFinish(2, done)
 
       const block = await promisify(makeBlock)()
-      await promisify(nodes[2].bitswap.put.bind(nodes[2].bitswap))(block)
+      await nodes[2].bitswap.put(block)
+      // await promisify(nodes[2].bitswap.put.bind(nodes[2].bitswap))(block)
 
       nodes[0].bitswap.get(block.cid).then((block) => {
         expect(block).to.not.exist()
@@ -135,7 +136,8 @@ describe('bitswap with DHT', function () {
 
   it('put a block in 2, get it in 0', async () => {
     const block = await promisify(makeBlock)()
-    await promisify(nodes[2].bitswap.put.bind(nodes[2].bitswap))(block)
+    nodes[2].bitswap.put(block)
+    // await promisify(nodes[2].bitswap.put.bind(nodes[2].bitswap))(block)
 
     const blockRetrieved = await nodes[0].bitswap.get(block.cid)
     expect(block.data).to.eql(blockRetrieved.data)

--- a/test/network/gen-bitswap-network.node.js
+++ b/test/network/gen-bitswap-network.node.js
@@ -46,7 +46,7 @@ describe('gen Bitswap network', function () {
         }),
         (cb) => each(
           blocks,
-          (b, cb) => node.bitswap.put(b, cb),
+          (b, cb) => node.bitswap.put(b).then(() => cb()),
           cb
         ),
         (cb) => Promise.all(_.range(100).map((i) => {
@@ -114,7 +114,7 @@ function round (nodeArr, n, cb) {
           return blocks[index]
         })
 
-        each(data, (d, cb) => node.bitswap.put(d, cb), cb)
+        each(data, (d, cb) => node.bitswap.put(d).then(() => cb()), cb)
       }), cb),
       (cb) => {
         d = (new Date()).getTime()

--- a/test/network/network.node.js
+++ b/test/network/network.node.js
@@ -123,10 +123,15 @@ describe('network', () => {
   })
 
   it('connectTo fail', (done) => {
-    networkA.connectTo(p2pB.peerInfo.id, (err) => {
-      expect(err).to.exist()
-      done()
-    })
+    (async () => {
+      try {
+        await networkA.connectTo(p2pB.peerInfo.id)
+        chai.assert.fail()
+      } catch (err) {
+        expect(err).to.exist()
+        done()
+      }
+    })()
   })
 
   it('onPeerConnected success', (done) => {
@@ -160,7 +165,11 @@ describe('network', () => {
   })
 
   it('connectTo success', (done) => {
-    networkA.connectTo(p2pB.peerInfo, done)
+    networkA.connectTo(p2pB.peerInfo).then(() => {
+      done()
+    }).catch((err) => {
+      expect(err).to.not.exist()
+    })
   })
 
   it('._receiveMessage success from Bitswap 1.0.0', (done) => {
@@ -279,7 +288,9 @@ describe('network', () => {
     function finish () {
       bitswapMockA._onPeerConnected = () => {}
       bitswapMockC._onPeerConnected = () => {}
-      networkA.connectTo(p2pC.peerInfo.id, done)
+      networkA.connectTo(p2pC.peerInfo.id).then(() => {
+        done()
+      })
     }
   })
 

--- a/test/utils/mocks.js
+++ b/test/utils/mocks.js
@@ -62,10 +62,9 @@ exports.mockNetwork = (calls, done) => {
   }
 
   return {
-    connectTo (p, cb) {
+    connectTo (p) {
       setImmediate(() => {
         connects.push(p)
-        cb()
       })
     },
     sendMessage (p, msg, cb) {

--- a/test/utils/mocks.js
+++ b/test/utils/mocks.js
@@ -77,8 +77,8 @@ exports.mockNetwork = (calls, done) => {
     start (callback) {
       setImmediate(() => callback())
     },
-    findAndConnect (cid, callback) {
-      setImmediate(() => callback())
+    findAndConnect (cid) {
+      return new Promise(() => {})
     },
     provide (cid, callback) {
       setImmediate(() => callback())

--- a/test/wantmanager/msg-queue.spec.js
+++ b/test/wantmanager/msg-queue.spec.js
@@ -75,9 +75,8 @@ describe('MessageQueue', () => {
     }
 
     const network = {
-      connectTo (p, cb) {
+      connectTo (p) {
         connects.push(p)
-        cb()
       },
       sendMessage (p, msg, cb) {
         messages.push([p, msg])


### PR DESCRIPTION
Early draft of making `js-ipfs-bitswap` async/await or AsyncIterable.

* `get()` now has an option whether to prompt the network or not, defaults to `true` which is similar to previous behaviour.
* Using the same `extendIterator` from `js-ipld`.