### PR TITLE
chore: update cids dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "bignumber.js": "^8.0.1",
-    "cids": "~0.5.8",
+    "cids": "~0.7.0",
     "debug": "^4.1.0",
     "ipfs-block": "~0.8.0",
     "just-debounce-it": "^1.1.0",


### PR DESCRIPTION
BREAKING CHANGE: v1 CIDs created by this module now default to base32 encoding when stringified

refs: https://github.com/ipfs/js-ipfs/issues/1995