### PR TITLE
Fix: ignore unwanted blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "dirty-chai": "^2.0.1",
     "ipfs-repo": "~0.26.3",
     "libp2p": "~0.24.2",
-    "libp2p-kad-dht": "~0.14.8",
+    "libp2p-kad-dht": "~0.15.0",
     "libp2p-mplex": "~0.8.4",
     "libp2p-secio": "~0.11.1",
     "libp2p-tcp": "~0.13.0",

--- a/test/bitswap-stats.js
+++ b/test/bitswap-stats.js
@@ -87,6 +87,7 @@ describe('bitswap stats', () => {
         statsComputeThrottleTimeout: 500 // fast update interval for tests
       }))
     bs = bitswaps[0]
+    bs.wm.wantBlocks(blocks.map(b => b.cid))
   })
 
   // start the first bitswap


### PR DESCRIPTION
This fixes a potential DoS attack, `ipfs-bitswap` was putting blocks in the blockstore even if they weren't wanted.