### PR TITLE
perf: use async/setImmediate instead of async/nextTick

### DIFF
--- a/src/decision-engine/index.js
+++ b/src/decision-engine/index.js
@@ -3,7 +3,7 @@
 const each = require('async/each')
 const eachSeries = require('async/eachSeries')
 const waterfall = require('async/waterfall')
-const nextTick = require('async/nextTick')
+const setImmediate = require('async/setImmediate')
 
 const map = require('async/map')
 const debounce = require('just-debounce-it')
@@ -66,7 +66,7 @@ class DecisionEngine {
           cb()
         })
       } else {
-        nextTick(cb)
+        setImmediate(cb)
       }
     }, cb)
   }
@@ -174,7 +174,7 @@ class DecisionEngine {
     const ledger = this._findOrCreate(peerId)
 
     if (msg.empty) {
-      return nextTick(cb)
+      return setImmediate(cb)
     }
 
     // If the message was a full wantlist clear the current one
@@ -185,7 +185,7 @@ class DecisionEngine {
     this._processBlocks(msg.blocks, ledger)
 
     if (msg.wantlist.size === 0) {
-      return nextTick(cb)
+      return setImmediate(cb)
     }
 
     let cancels = []
@@ -289,12 +289,12 @@ class DecisionEngine {
 
   start (callback) {
     this._running = true
-    nextTick(() => callback())
+    setImmediate(() => callback())
   }
 
   stop (callback) {
     this._running = false
-    nextTick(() => callback())
+    setImmediate(() => callback())
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const reject = require('async/reject')
 const each = require('async/each')
 const series = require('async/series')
 const map = require('async/map')
-const nextTick = require('async/nextTick')
+const setImmediate = require('async/setImmediate')
 
 const WantManager = require('./want-manager')
 const Network = require('./network')
@@ -112,7 +112,7 @@ class Bitswap {
       (has, cb) => {
         this._updateReceiveCounters(peerId.toB58String(), block, has)
         if (has || !wasWanted) {
-          return nextTick(cb)
+          return setImmediate(cb)
         }
 
         this._putBlock(block, cb)
@@ -314,7 +314,7 @@ class Bitswap {
       (cb) => this.blockstore.has(block.cid, cb),
       (has, cb) => {
         if (has) {
-          return nextTick(cb)
+          return setImmediate(cb)
         }
 
         this._putBlock(block, cb)

--- a/src/network.js
+++ b/src/network.js
@@ -4,7 +4,7 @@ const lp = require('pull-length-prefixed')
 const pull = require('pull-stream')
 const waterfall = require('async/waterfall')
 const each = require('async/each')
-const nextTick = require('async/nextTick')
+const setImmediate = require('async/setImmediate')
 
 const Message = require('./types/message')
 const CONSTANTS = require('./constants')
@@ -44,7 +44,7 @@ class Network {
       .filter((peer) => peer.isConnected())
       .forEach((peer) => this._onPeerConnect((peer)))
 
-    nextTick(() => callback())
+    setImmediate(() => callback())
   }
 
   stop (callback) {
@@ -56,7 +56,7 @@ class Network {
     this.libp2p.removeListener('peer:connect', this._onPeerConnect)
     this.libp2p.removeListener('peer:disconnect', this._onPeerDisconnect)
 
-    nextTick(() => callback())
+    setImmediate(() => callback())
   }
 
   // Handles both types of bitswap messgages

--- a/src/types/message/index.js
+++ b/src/types/message/index.js
@@ -5,7 +5,7 @@ const Block = require('ipfs-block')
 const isEqualWith = require('lodash.isequalwith')
 const assert = require('assert')
 const each = require('async/each')
-const nextTick = require('async/nextTick')
+const setImmediate = require('async/setImmediate')
 const CID = require('cids')
 const codecName = require('multicodec/src/name-table')
 const vd = require('varint-decoder')
@@ -140,7 +140,7 @@ BitswapMessage.deserialize = (raw, callback) => {
   try {
     decoded = pbm.Message.decode(raw)
   } catch (err) {
-    return nextTick(() => callback(err))
+    return setImmediate(() => callback(err))
   }
 
   const isFull = (decoded.wantlist && decoded.wantlist.full) || false
@@ -188,7 +188,7 @@ BitswapMessage.deserialize = (raw, callback) => {
   if (decoded.payload.length > 0) {
     return each(decoded.payload, (p, cb) => {
       if (!p.prefix || !p.data) {
-        return nextTick(cb)
+        return setImmediate(cb)
       }
       const values = vd(p.prefix)
       const cidVersion = values[0]

--- a/src/want-manager/index.js
+++ b/src/want-manager/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const nextTick = require('async/nextTick')
+const setImmediate = require('async/setImmediate')
 const Message = require('../types/message')
 const Wantlist = require('../types/wantlist')
 const CONSTANTS = require('../constants')
@@ -124,13 +124,13 @@ module.exports = class WantManager {
       this.peers.forEach((p) => p.addMessage(fullwantlist))
     }, 60 * 1000)
 
-    nextTick(() => callback())
+    setImmediate(() => callback())
   }
 
   stop (callback) {
     this.peers.forEach((mq) => this.disconnected(mq.peerId))
 
     clearInterval(this.timer)
-    nextTick(() => callback())
+    setImmediate(() => callback())
   }
 }


### PR DESCRIPTION
Building tools such as Webpack, automatically inject process.nextTick which uses https://github.com/defunctzombie/node-process/blob/master/browser.js, which relies on timers.
Because it uses timers, things become very slow when the tab is not focused/visible because browsers throttle timers (1Hz), see https://developers.google.com/web/updates/2017/03/background_tabs.

The setImmediate polyfill uses a postMessage trick to make it work reliable, even if the tab is not focused.

Related: https://github.com/webtorrent/webtorrent/issues/1568

Closes #196 