### PR TITLE
fix: use multicodec correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ipfs-block": "~0.8.0",
     "just-debounce-it": "^1.1.0",
     "moving-average": "^1.0.0",
-    "multicodec": "~0.5.0",
+    "multicodec": "~0.5.7",
     "multihashing-async": "^0.8.0",
     "protons": "^1.0.1",
     "pull-length-prefixed": "^1.3.1",

--- a/src/types/message/index.js
+++ b/src/types/message/index.js
@@ -3,7 +3,7 @@
 const protons = require('protons')
 const Block = require('ipfs-block')
 const CID = require('cids')
-const codecName = require('multicodec/src/name-table')
+const { getName } = require('multicodec')
 const vd = require('varint-decoder')
 const multihashing = require('multihashing-async')
 const { isMapEqual } = require('../../utils')
@@ -159,7 +159,7 @@ BitswapMessage.deserialize = async (raw) => {
       const hashAlg = values[2]
       // const hashLen = values[3] // We haven't need to use this so far
       const hash = await multihashing(p.data, hashAlg)
-      const cid = new CID(cidVersion, codecName[multicodec.toString('16')], hash)
+      const cid = new CID(cidVersion, getName(multicodec), hash)
       msg.addBlock(new Block(p.data, cid))
     }))
     return msg


### PR DESCRIPTION
Correctly uses `multicodec` API instead of going around! Please see https://github.com/multiformats/js-multicodec/issues/54.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>