### PR TITLE
chore: update multicodec

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ipfs-block": "~0.8.0",
     "just-debounce-it": "^1.1.0",
     "moving-average": "^1.0.0",
-    "multicodec": "~0.5.7",
+    "multicodec": "~1.0.0",
     "multihashing-async": "^0.8.0",
     "protons": "^1.0.1",
     "pull-length-prefixed": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ipfs-block": "~0.8.0",
     "just-debounce-it": "^1.1.0",
     "moving-average": "^1.0.0",
-    "multicodec": "~1.0.0",
+    "multicodec": "^1.0.0",
     "multihashing-async": "^0.8.0",
     "protons": "^1.0.1",
     "pull-length-prefixed": "^1.3.1",


### PR DESCRIPTION
Updating multicodec to 1.0.0 as we decided to bump it to 1.0.0 and deprecate 0.x.