### PR TITLE
fix: await result of receiving blocks

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -77,7 +77,7 @@ class Network {
           for await (const data of source) {
             try {
               const message = await Message.deserialize(data.slice())
-              this.bitswap._receiveMessage(connection.remotePeer, message)
+              await this.bitswap._receiveMessage(connection.remotePeer, message)
             } catch (err) {
               this.bitswap._receiveError(err)
               break


### PR DESCRIPTION
`bitswap._receiveMessage` is an async function so you need to `await` on it in order to correctly handle any errors encountered.

I've been seeing `unhandledPromiseRejection` events during test runs, turns out it's when you spin up two nodes, get them to dial each other and transfer data - the tests can shut the nodes down and clean up their repos before they've finished processing incoming blocks leading to `Error: ENOENT: no such file or directory` errors as the repos are deleted out from under the blockstore.

`await`ing on the result of `bitswap._receiveMessage` fixes this by handling the error.