### PR TITLE
fix: blocks may not be in the blockstore yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "promisify-es6": "^1.0.3",
     "rimraf": "^3.0.0",
     "safe-buffer": "^5.1.2",
+    "sinon": "^9.0.0",
     "stats-lite": "^2.2.0",
     "uuid": "^3.3.2"
   },


### PR DESCRIPTION
Because some blockstore implementations batch up write before committing them to disk or wherever, they may not be available when we think they should be.

I noticed this module throwing unhandledPromiseRejections around this so the change here handles missing blocks by putting the task back into the queue to process later, with a fairly arbitrary 5x limit on processing a given task.