### PR TITLE
fix: re-sort queue after adding tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/ipfs/js-ipfs-bitswap#readme",
   "devDependencies": {
     "@nodeutils/defaults-deep": "^1.1.0",
-    "aegir": "^21.9.0",
+    "aegir": "^21.10.1",
     "async-iterator-all": "^1.0.0",
     "benchmark": "^2.1.4",
     "buffer": "^5.6.0",

--- a/src/decision-engine/req-queue.js
+++ b/src/decision-engine/req-queue.js
@@ -54,12 +54,11 @@ class RequestQueue {
    */
   pushTasks (peerId, tasks) {
     let peerTasks = this._byPeer.get(peerId.toB58String())
-    if (peerTasks) {
-      peerTasks.pushTasks(tasks)
-      return
+
+    if (!peerTasks) {
+      peerTasks = new PeerTasks(peerId, this._taskMerger)
     }
 
-    peerTasks = new PeerTasks(peerId, this._taskMerger)
     peerTasks.pushTasks(tasks)
     this._byPeer.set(peerId.toB58String(), peerTasks)
   }

--- a/test/decision-engine/req-queue.spec.js
+++ b/test/decision-engine/req-queue.spec.js
@@ -237,6 +237,31 @@ describe('Request Queue', () => {
     })
   })
 
+  it('resorts queue when new peer tasks are added where peer tasks already exist', () => {
+    const rq = new RequestQueue()
+
+    rq.pushTasks(peerIds[0], [{
+      topic: 'a',
+      size: 0,
+      priority: 1
+    }])
+    rq.pushTasks(peerIds[1], [{
+      topic: 'a',
+      size: 0,
+      priority: 1
+    }])
+    rq.pushTasks(peerIds[0], [{
+      topic: 'a',
+      size: 1,
+      priority: 1
+    }])
+
+    // _byPeer map should have been resorted to put peer0
+    // fist in the queue
+    const { peerId } = rq.popTasks(16)
+    expect(peerId).to.eql(peerIds[0])
+  })
+
   describe('remove', () => {
     it('removes tasks by peer and topic', () => {
       const rq = new RequestQueue()


### PR DESCRIPTION
When tasks are added to an existing list of tasks for a given peer, we need to sort the queue to ensure the order is correct, otherwise we never process pending tasks as task lists with pending tasks need to be moved up the queue.

Fixes the build problems exposed in ipfs/js-ipfs#2992

Also upgrades aegir to a safe version.