### PR TITLE
perf: decrease wantlist send debounce time

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -9,5 +9,6 @@ module.exports = {
   provideTimeout: 15 * SECOND,
   kMaxPriority: Math.pow(2, 31) - 1,
   rebroadcastDelay: 10 * SECOND,
-  maxListeners: 1000
+  maxListeners: 1000,
+  wantlistSendDebounceAmount: 10
 }

--- a/src/want-manager/msg-queue.js
+++ b/src/want-manager/msg-queue.js
@@ -4,6 +4,7 @@ const debounce = require('just-debounce-it')
 
 const Message = require('../types/message')
 const logger = require('../utils').logger
+const { wantlistSendDebounceAmount } = require('../constants')
 
 module.exports = class MsgQueue {
   constructor (selfPeerId, otherPeerId, network) {
@@ -13,7 +14,7 @@ module.exports = class MsgQueue {
 
     this._entries = []
     this._log = logger(selfPeerId, 'msgqueue', otherPeerId.toB58String().slice(0, 8))
-    this.sendEntries = debounce(this._sendEntries.bind(this), 200)
+    this.sendEntries = debounce(this._sendEntries.bind(this), wantlistSendDebounceAmount)
   }
 
   addMessage (msg) {


### PR DESCRIPTION
We wait 200ms before sending wantlists to remote peers which is an eternity. I'm not sure how this figure was arrived at but I've reduced it to 10ms which has increased the js->js transfer times in the interop tests to:

| Data    | 200ms    | 10ms    | Speedup |
|---------|----------|---------|---------|
| 1.02 kB | 486ms    | 142ms   | 342%    |
| 63.5 kB | 449ms    | 119ms   | 377%    |
| 65.5 kB | 436ms    | 105ms   | 415%    |
| 524 kB  | 1287ms   | 210ms   | 613%    |
| 786 kB  | 1676ms   | 282ms   | 594%    |
| 1.05 MB | 2066ms   | 326ms   | 634%    |
| 1.05 MB | 2123ms   | 330ms   | 643%    |
| 4.19 MB | 7091ms   | 1045ms  | 679%    |
| 8.39 MB | 13711ms  | 1927ms  | 712%    |
| 67.1 MB | 107704ms | 13462ms | 800%    |
| 134 MB  | 214988ms | 26038ms | 826%    |