### PR TITLE
fix: do not rebroadcast want list

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -8,6 +8,5 @@ module.exports = {
   hasBlockTimeout: 15 * SECOND,
   provideTimeout: 15 * SECOND,
   kMaxPriority: Math.pow(2, 31) - 1,
-  rebroadcastDelay: 10 * SECOND,
   maxListeners: 1000
 }

--- a/src/want-manager/index.js
+++ b/src/want-manager/index.js
@@ -112,16 +112,6 @@ module.exports = class WantManager {
   }
 
   start () {
-    // resend entire wantlist every so often
-    this.timer = setInterval(() => {
-      this._log('resend full-wantlist')
-      const fullwantlist = new Message(true)
-      this.wantlist.forEach((entry) => {
-        fullwantlist.addEntry(entry.cid, entry.priority)
-      })
-
-      this.peers.forEach((p) => p.addMessage(fullwantlist))
-    }, 60 * 1000)
   }
 
   stop () {


### PR DESCRIPTION
We should not need to rebroadcast our wantlist, because we send it to newly connected peers.

Rebroadcasting is a throwback to when the network was less reliable, but if the connection is unreliable it is dropped and a new connection established, which triggers sending the whole wantlist as the remote is seen as a newly connected peer.

fixes #160