### PR TITLE
fix: pass peer id to onPeerConnect

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -53,7 +53,7 @@ class Network {
     for (const peer of this.libp2p.peerStore.peers.values()) {
       const conn = this.libp2p.connectionManager.get(peer.id)
 
-      conn && this._onPeerConnect(conn)
+      conn && this._onPeerConnect(conn.remotePeer)
     }
   }
 


### PR DESCRIPTION
The persistent peer store in libp2p 0.28 means sometimes we know about peers when we start up, so we try to start bitswap for them when we start up if we have an open connection already.

The connection object has a remotePeer property that should be used instead of passing the whole thing to `this._onPeerConnect`.

Adds a test for the above.

Fixes ipfs/js-ipfs#3182