### PR TITLE
fix: update provider multiaddrs before dial

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -142,7 +142,9 @@ class Network {
     const connectAttempts = []
     for await (const provider of this.findProviders(cid, CONSTANTS.maxProvidersPerRequest, options)) {
       this._log('connecting to providers', provider.id.toB58String())
-      connectAttempts.push(this.connectTo(provider, options))
+
+      this._libp2p.peerStore.addressBook.set(provider.id, provider.multiaddrs)
+      connectAttempts.push(this.connectTo(provider.id, options))
     }
     await Promise.all(connectAttempts)
   }

--- a/src/network.js
+++ b/src/network.js
@@ -141,9 +141,7 @@ class Network {
   async findAndConnect (cid, options) {
     const connectAttempts = []
     for await (const provider of this.findProviders(cid, CONSTANTS.maxProvidersPerRequest, options)) {
-      this._log('connecting to providers', provider.id.toB58String())
-
-      this._libp2p.peerStore.addressBook.set(provider.id, provider.multiaddrs)
+      this._log(`connecting to provider ${provider.id}`)
       connectAttempts.push(this.connectTo(provider.id, options))
     }
     await Promise.all(connectAttempts)


### PR DESCRIPTION
The output of `libp2p.contentRouting.findProviders()` is `AsyncIterable<{ id: PeerId, multiaddrs: Multiaddr[] }>`
and not `AsyncIterable<PeerId>` as the code seems to assume.

In order to ensure we can successfully dial a content provider we've not
dialled before, add their multiaddrs to the peer store before dialling them.

@vasco-santos is this the right place to do this?  Seems like it should happen in libp2p?