### PR TITLE
fix: fixes bignumber import for type gen

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npm install
-      - run: npx aegir test -t node --bail --cov
+      - run: npx aegir test -t node --bail --cov -- --exit # TODO remove - https://mochajs.org/#-exit
       - uses: codecov/codecov-action@v1
   test-chrome:
     needs: check
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: microsoft/playwright-github-action@v1
       - run: npm install
-      - run: npx aegir test -t browser -t webworker --bail -- --browser firefox
+      - run: npx aegir test -t browser -t webworker --bail -- --browser firefox --exit # TODO remove - https://mochajs.org/#-exit
   test-webkit:
     needs: check
     runs-on: ubuntu-latest
@@ -61,18 +61,18 @@ jobs:
       - uses: actions/checkout@v2
       - uses: microsoft/playwright-github-action@v1
       - run: npm install
-      - run: npx aegir test -t browser -t webworker --bail --timeout 10000 -- --browser webkit
+      - run: npx aegir test -t browser -t webworker --bail --timeout 10000 -- --browser webkit --exit # TODO remove - https://mochajs.org/#-exit
   test-electron-main:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-      - run: npx xvfb-maybe aegir test -t electron-main --bail
+      - run: npx xvfb-maybe aegir test -t electron-main --bail -- --exit # TODO remove - https://mochajs.org/#-exit
   test-electron-renderer:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-      - run: npx xvfb-maybe aegir test -t electron-renderer --bail
+      - run: npx xvfb-maybe aegir test -t electron-renderer --bail -- --exit # TODO remove - https://mochajs.org/#-exit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npm install
-      - run: npx aegir test -t node --bail --cov -- --exit # TODO remove - https://mochajs.org/#-exit
+      - run: npx aegir test -t node --bail --cov
       - uses: codecov/codecov-action@v1
   test-chrome:
     needs: check
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: microsoft/playwright-github-action@v1
       - run: npm install
-      - run: npx aegir test -t browser -t webworker --bail -- --exit # TODO remove - https://mochajs.org/#-exit
+      - run: npx aegir test -t browser -t webworker --bail
       - uses: codecov/codecov-action@v1
   test-firefox:
     needs: check
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: microsoft/playwright-github-action@v1
       - run: npm install
-      - run: npx aegir test -t browser -t webworker --bail -- --browser firefox --exit # TODO remove - https://mochajs.org/#-exit
+      - run: npx aegir test -t browser -t webworker --bail -- --browser firefox
   test-webkit:
     needs: check
     runs-on: ubuntu-latest
@@ -61,18 +61,18 @@ jobs:
       - uses: actions/checkout@v2
       - uses: microsoft/playwright-github-action@v1
       - run: npm install
-      - run: npx aegir test -t browser -t webworker --bail --timeout 10000 -- --browser webkit --exit # TODO remove - https://mochajs.org/#-exit
+      - run: npx aegir test -t browser -t webworker --bail --timeout 10000 -- --browser webkit
   test-electron-main:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-      - run: npx xvfb-maybe aegir test -t electron-main --bail -- --exit # TODO remove - https://mochajs.org/#-exit
+      - run: npx xvfb-maybe aegir test -t electron-main --bail
   test-electron-renderer:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-      - run: npx xvfb-maybe aegir test -t electron-renderer --bail -- --exit # TODO remove - https://mochajs.org/#-exit
+      - run: npx xvfb-maybe aegir test -t electron-renderer --bail

--- a/src/stats/stat.js
+++ b/src/stats/stat.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { EventEmitter } = require('events')
-const Big = require('bignumber.js').default
+const { BigNumber: Big } = require('bignumber.js')
 const MovingAverage = require('moving-average')
 
 /**


### PR DESCRIPTION
Otherwise you get errors like:

```
./node_modules/ipfs-bitswap/dist/src/stats/stat.d.ts(87,20): error TS1359: Identifier expected. 'default' is a reserved word that cannot be used here.
```