### PR TITLE
fix: specify pbjs root

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:proto && npm run build:proto-types && npm run build:bundle",
-    "build:proto": "pbjs -t static-module -w commonjs --force-number --no-verify --no-delimited --no-create --no-beautify --no-defaults --lint eslint-disable -o src/types/message/message.js src/types/message/message.proto",
+    "build:proto": "pbjs -t static-module -w commonjs -r bitswap --force-number --no-verify --no-delimited --no-create --no-beautify --no-defaults --lint eslint-disable -o src/types/message/message.js src/types/message/message.proto",
     "build:proto-types": "pbts -o src/types/message/message.d.ts src/types/message/message.js",
     "build:bundle": "aegir build",
     "test": "aegir test",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:proto && npm run build:proto-types && npm run build:bundle",
-    "build:proto": "pbjs -t static-module -w commonjs -r bitswap --force-number --no-verify --no-delimited --no-create --no-beautify --no-defaults --lint eslint-disable -o src/types/message/message.js src/types/message/message.proto",
+    "build:proto": "pbjs -t static-module -w commonjs -r ipfs-bitswap --force-number --no-verify --no-delimited --no-create --no-beautify --no-defaults --lint eslint-disable -o src/types/message/message.js src/types/message/message.proto",
     "build:proto-types": "pbts -o src/types/message/message.d.ts src/types/message/message.js",
     "build:bundle": "aegir build",
     "test": "aegir test",

--- a/src/types/message/message.js
+++ b/src/types/message/message.js
@@ -7,7 +7,7 @@ var $protobuf = require("protobufjs/minimal");
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-var $root = $protobuf.roots.bitswap || ($protobuf.roots.bitswap = {});
+var $root = $protobuf.roots["ipfs-bitswap"] || ($protobuf.roots["ipfs-bitswap"] = {});
 
 $root.Message = (function() {
 

--- a/src/types/message/message.js
+++ b/src/types/message/message.js
@@ -7,7 +7,7 @@ var $protobuf = require("protobufjs/minimal");
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+var $root = $protobuf.roots.bitswap || ($protobuf.roots.bitswap = {});
 
 $root.Message = (function() {
 


### PR DESCRIPTION
If we do not specify a root for pbjs, the default is used which is
shared globally, so we can't have a protobuf message called `Message`
that exists for both `ipfs-bitswap` and `libp2p-kad-dht`, for example.

Specify a root to add a scope to the declaration of protobuf messages.