### PR TITLE
fix: iterate over connections instead of every peer in the peerstore

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "iso-random-stream": "^2.0.0",
     "it-all": "^1.0.5",
     "it-drain": "^1.0.4",
-    "libp2p": "next",
+    "libp2p": "^0.37.3",
     "lodash.difference": "^4.5.0",
     "lodash.flatten": "^4.4.0",
     "lodash.range": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,6 @@
     "@libp2p/mplex": "^1.0.2",
     "@libp2p/peer-id": "^1.1.8",
     "@libp2p/peer-id-factory": "^1.0.8",
-    "@libp2p/peer-store": "^1.0.7",
     "@libp2p/tcp": "^1.0.6",
     "@nodeutils/defaults-deep": "^1.1.0",
     "@types/debug": "^4.1.5",

--- a/src/network.js
+++ b/src/network.js
@@ -93,11 +93,14 @@ export class Network {
    * @param {Stream} connection.stream - A duplex iterable stream
    * @param {Connection} connection.connection - A libp2p Connection
    */
-  async _onConnection ({ protocol, stream, connection }) {
-    if (!this._running) { return }
-    this._log('incoming new bitswap %s connection from %p', protocol, connection.remotePeer)
+  _onConnection ({ protocol, stream, connection }) {
+    if (!this._running) {
+      return
+    }
 
-    try {
+    void Promise.resolve().then(async () => {
+      this._log('incoming new bitswap %s connection from %p', protocol, connection.remotePeer)
+
       await pipe(
         stream,
         lp.decode(),
@@ -113,9 +116,10 @@ export class Network {
           }
         }
       )
-    } catch (err) {
+    })
+    .catch(err => {
       this._log(err)
-    }
+    })
   }
 
   /**

--- a/src/network.js
+++ b/src/network.js
@@ -67,8 +67,8 @@ export class Network {
     this._registrarId = await this._libp2p.registrar.register(this._protocols, topology)
 
     // All existing connections are like new ones for us
-    await this._libp2p.peerStore.forEach(peer => {
-      this._libp2p.getConnections(peer.id).forEach(conn => this._onPeerConnect(conn.remotePeer))
+    this._libp2p.getConnections().forEach(conn => {
+      this._onPeerConnect(conn.remotePeer)
     })
   }
 

--- a/src/network.js
+++ b/src/network.js
@@ -98,7 +98,7 @@ export class Network {
       return
     }
 
-    void Promise.resolve().then(async () => {
+    Promise.resolve().then(async () => {
       this._log('incoming new bitswap %s connection from %p', protocol, connection.remotePeer)
 
       await pipe(
@@ -117,9 +117,9 @@ export class Network {
         }
       )
     })
-    .catch(err => {
-      this._log(err)
-    })
+      .catch(err => {
+        this._log(err)
+      })
   }
 
   /**

--- a/test/bitswap.js
+++ b/test/bitswap.js
@@ -37,9 +37,7 @@ describe('start/stop', () => {
       registrar: {
         register: () => {}
       },
-      peerStore: {
-        forEach: async () => {}
-      }
+      getConnections: () => []
     }
     // @ts-ignore not a full libp2p
     const bitswap = new Bitswap(libp2p, new MemoryBlockstore())

--- a/test/network/network.node.js
+++ b/test/network/network.node.js
@@ -307,10 +307,7 @@ describe('network', () => {
       registrar: {
         register: sinon.stub()
       },
-      // @ts-expect-error incomplete implementation
-      peerStore: {
-        forEach: async () => {}
-      },
+      getConnections: () => [],
       dial: mockDial,
       handle: sinon.stub()
     }

--- a/test/utils/mocks.js
+++ b/test/utils/mocks.js
@@ -1,12 +1,9 @@
-import { PersistentPeerStore } from '@libp2p/peer-store'
 import { MemoryBlockstore } from 'blockstore-core/memory'
 import { EventEmitter } from 'events'
-import { MemoryDatastore } from 'datastore-core/memory'
 import { Bitswap } from '../../src/bitswap.js'
 import { Network } from '../../src/network.js'
 import { Stats } from '../../src/stats/index.js'
 import { peerIdFromBytes } from '@libp2p/peer-id'
-import { Components } from '@libp2p/interfaces/components'
 import { createLibp2pNode } from './create-libp2p-node.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
@@ -56,12 +53,8 @@ export const mockLibp2pNode = () => {
     swarm: {
       setMaxListeners () {}
     },
-    peerStore: new PersistentPeerStore({
-      addressFilter: async () => true
-    })
+    getConnections: () => []
   })
-
-  libp2p.peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
 
   // @ts-expect-error not all libp2p fields are implemented
   return libp2p


### PR DESCRIPTION
When starting up, only look at the current connections rather than trying to get the connections for every peer in the peerstore as this is much slower.