### PR TITLE
fix: time out slow senders

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "@libp2p/tracked-map": "^2.0.0",
     "@multiformats/multiaddr": "^10.1.8",
     "@vascosantos/moving-average": "^1.1.0",
+    "abortable-iterator": "^4.0.2",
     "any-signal": "^3.0.0",
     "blockstore-core": "^1.0.2",
     "debug": "^4.2.0",
@@ -179,6 +180,7 @@
     "multiformats": "^9.0.4",
     "protobufjs": "^6.10.2",
     "readable-stream": "^4.0.0",
+    "timeout-abort-controller": "^3.0.0",
     "uint8arrays": "^3.0.0",
     "varint": "^6.0.0",
     "varint-decoder": "^1.0.0"

--- a/src/bitswap.js
+++ b/src/bitswap.js
@@ -51,6 +51,7 @@ export class Bitswap extends BaseBlockstore {
    * @param {number} [options.statsComputeThrottleMaxQueueSize=1000]
    * @param {number} [options.maxInboundStreams=32]
    * @param {number} [options.maxOutboundStreams=32]
+   * @param {number} [options.incomingStreamTimeout=30000]
    * @param {MultihashHasherLoader} [options.hashLoader]
    */
   constructor (libp2p, blockstore, options = {}) {
@@ -72,7 +73,8 @@ export class Bitswap extends BaseBlockstore {
     this.network = new Network(libp2p, this, this._stats, {
       hashLoader: options.hashLoader,
       maxInboundStreams: options.maxInboundStreams,
-      maxOutboundStreams: options.maxOutboundStreams
+      maxOutboundStreams: options.maxOutboundStreams,
+      incomingStreamTimeout: options.incomingStreamTimeout
     })
 
     // local database

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import { Bitswap } from './bitswap.js'
  * @param {number} [options.statsComputeThrottleMaxQueueSize=1000]
  * @param {number} [options.maxInboundStreams=32]
  * @param {number} [options.maxOutboundStreams=128]
+ * @param {number} [options.incomingStreamTimeout=30000]
  * @param {MultihashHasherLoader} [options.hashLoader]
  * @returns {IPFSBitswap}
  */


### PR DESCRIPTION
If no Bitswap message is received from a remote after 30s, close the stream.

The timeout value is configurable.