### PR TITLE
fix: reset timeout controller when messages are received

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -139,6 +139,9 @@ export class Network {
               this._bitswap._receiveError(err)
               break
             }
+
+            // we have received some data so reset the timeout controller
+            controller.reset()
           }
         }
       )


### PR DESCRIPTION
Otherwise all bitswap streams are closed after 30s