### PR TITLE
fix: mark package as side-effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,5 +208,6 @@
   },
   "browser": {
     "dist/test/utils/create-libp2p-node.js": false
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
[Tree shaking](https://webpack.js.org/guides/tree-shaking/) results in smaller web bundles by deleting unused code.

This module is side-effect free so mark it as such to signal to bundlers that unused exports can be excluded from bundles.